### PR TITLE
fix: comprehensive code review improvements (11 fixes)

### DIFF
--- a/docs/guides/development-standards.md
+++ b/docs/guides/development-standards.md
@@ -406,7 +406,7 @@ public class ExampleViewModel : ReactiveObject, IDisposable
 private readonly ILogger<MyClass> _logger;
 
 // Structured logging - ALWAYS use this pattern
-_logger.LogInformation("User performed action: {Action} at {Timestamp}", action, DateTime.Now);
+_logger.LogInformation("User performed action: {Action} at {Timestamp}", action, DateTime.UtcNow);
 _logger.LogError(exception, "Error occurred in {Method}", nameof(MyMethod));
 ```
 

--- a/specs/008-memory-regions-profiling/quickstart.md
+++ b/specs/008-memory-regions-profiling/quickstart.md
@@ -91,8 +91,8 @@ namespace S7Tools.Core.Models
         public Guid Id { get; set; } = Guid.NewGuid();
         public string Name { get; set; } = string.Empty;
         public string Description { get; set; } = string.Empty;
-        public DateTime CreatedAt { get; set; } = DateTime.Now;
-        public DateTime UpdatedAt { get; set; } = DateTime.Now;
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+        public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
         public bool IsActive { get; set; }
         public List<MemorySegment> Segments { get; set; } = new();
     }
@@ -221,7 +221,7 @@ public class MemoryRegionProfileService : StandardProfileManager<MemoryRegionPro
     {
         Id = Guid.NewGuid(),
         Name = "Default Memory Regions",
-        CreatedAt = DateTime.Now,
+        CreatedAt = DateTime.UtcNow,
         Segments = new List<MemorySegment>
         {
             new() { Name = ".text", StartAddress = "0x08000000", Size = 128 * 1024, Type = MemorySegmentType.Flash },

--- a/specs/008-memory-regions-profiling/research.md
+++ b/specs/008-memory-regions-profiling/research.md
@@ -26,7 +26,7 @@ public class MemoryRegionProfileService : StandardProfileManager<MemoryRegionPro
     {
         Id = Guid.NewGuid(),
         Name = "Default Memory Regions",
-        CreatedAt = DateTime.Now,
+        CreatedAt = DateTime.UtcNow,
         Segments = new List<MemorySegment>
         {
             new() { Name = ".text", StartAddress = "0x08000000", Size = 128 * 1024, Type = MemorySegmentType.Flash },

--- a/src/S7Tools.Core/Constants/README.md
+++ b/src/S7Tools.Core/Constants/README.md
@@ -13,8 +13,8 @@ This directory contains centralized constant definitions used throughout the S7T
 ```csharp
 using S7Tools.Core.Constants;
 
-string shortDate = DateTime.Now.ToString(DateTimeFormats.ShortDateTime);
-string fileTimestamp = DateTime.Now.ToString(DateTimeFormats.FileTimestamp);
+string shortDate = DateTime.UtcNow.ToString(DateTimeFormats.ShortDateTime);
+string fileTimestamp = DateTime.UtcNow.ToString(DateTimeFormats.FileTimestamp);
 ```
 
 **Available Formats**:

--- a/src/S7Tools.Core/Models/Jobs/TaskExecution.cs
+++ b/src/S7Tools.Core/Models/Jobs/TaskExecution.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
+
+using S7Tools.Core.Services.Interfaces;
+
 namespace S7Tools.Core.Models.Jobs;
 
 /// <summary>
@@ -24,6 +27,43 @@ public class TaskExecution : INotifyPropertyChanged
     private long? _outputFileSize;
     private TimeSpan? _estimatedTimeRemaining;
     private IReadOnlyList<ResourceKey> _lockedResources = [];
+
+    /// <summary>
+    /// Event triggered when a property value changes.
+    /// </summary>
+    private ITimeProvider? _timeProvider;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TaskExecution"/> class.
+    /// Default constructor for serialization.
+    /// </summary>
+    public TaskExecution()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TaskExecution"/> class with a time provider.
+    /// </summary>
+    /// <param name="timeProvider">The time provider to use for timestamps.</param>
+    public TaskExecution(ITimeProvider timeProvider)
+    {
+        _timeProvider = timeProvider;
+        CreatedAt = _timeProvider.GetUtcNow();
+    }
+
+    /// <summary>
+    /// Initializes the time provider for this instance (e.g. after deserialization).
+    /// </summary>
+    /// <param name="timeProvider">The time provider.</param>
+    public void Initialize(ITimeProvider timeProvider)
+    {
+        _timeProvider = timeProvider;
+    }
+
+    /// <summary>
+    /// Helper to get UTC now from provider or fallback.
+    /// </summary>
+    private DateTime UtcNow => _timeProvider?.GetUtcNow() ?? DateTime.UtcNow;
 
     /// <summary>
     /// Event triggered when a property value changes.
@@ -269,7 +309,7 @@ public class TaskExecution : INotifyPropertyChanged
     /// <summary>
     /// Gets the total time since the task was created.
     /// </summary>
-    public TimeSpan TotalTime => DateTime.UtcNow - CreatedAt;
+    public TimeSpan TotalTime => UtcNow - CreatedAt;
 
     /// <summary>
     /// Gets a value indicating whether the task is in a terminal state.
@@ -303,15 +343,15 @@ public class TaskExecution : INotifyPropertyChanged
         switch (newState)
         {
             case TaskState.Queued:
-                QueuedAt = DateTime.UtcNow;
+                QueuedAt = UtcNow;
                 break;
             case TaskState.Running:
-                StartedAt = DateTime.UtcNow;
+                StartedAt = UtcNow;
                 break;
             case TaskState.Completed:
             case TaskState.Failed:
             case TaskState.Cancelled:
-                CompletedAt = DateTime.UtcNow;
+                CompletedAt = UtcNow;
                 break;
         }
 
@@ -371,7 +411,7 @@ public class TaskExecution : INotifyPropertyChanged
             // Calculate Speed and ETC
             if (hasBytes && TotalBytes.HasValue && TotalBytes.Value > 0)
             {
-                var now = DateTime.UtcNow;
+                var now = UtcNow;
                 if (_lastProgressUpdate != DateTime.MinValue && now > _lastProgressUpdate)
                 {
                     double seconds = (now - _lastProgressUpdate).TotalSeconds;
@@ -408,7 +448,7 @@ public class TaskExecution : INotifyPropertyChanged
                     if (remainingSeconds < 86400)
                     {
                         EstimatedTimeRemaining = TimeSpan.FromSeconds(remainingSeconds);
-                        EstimatedTimeCompletion = DateTime.UtcNow.AddSeconds(remainingSeconds);
+                        EstimatedTimeCompletion = UtcNow.AddSeconds(remainingSeconds);
                     }
                     OnPropertyChanged(nameof(EstimatedTimeRemaining));
                     OnPropertyChanged(nameof(EstimatedTimeCompletion));

--- a/src/S7Tools.Core/Models/Jobs/TaskExecution.cs
+++ b/src/S7Tools.Core/Models/Jobs/TaskExecution.cs
@@ -269,7 +269,7 @@ public class TaskExecution : INotifyPropertyChanged
     /// <summary>
     /// Gets the total time since the task was created.
     /// </summary>
-    public TimeSpan TotalTime => DateTime.Now - CreatedAt;
+    public TimeSpan TotalTime => DateTime.UtcNow - CreatedAt;
 
     /// <summary>
     /// Gets a value indicating whether the task is in a terminal state.
@@ -303,15 +303,15 @@ public class TaskExecution : INotifyPropertyChanged
         switch (newState)
         {
             case TaskState.Queued:
-                QueuedAt = DateTime.Now;
+                QueuedAt = DateTime.UtcNow;
                 break;
             case TaskState.Running:
-                StartedAt = DateTime.Now;
+                StartedAt = DateTime.UtcNow;
                 break;
             case TaskState.Completed:
             case TaskState.Failed:
             case TaskState.Cancelled:
-                CompletedAt = DateTime.Now;
+                CompletedAt = DateTime.UtcNow;
                 break;
         }
 
@@ -408,7 +408,7 @@ public class TaskExecution : INotifyPropertyChanged
                     if (remainingSeconds < 86400)
                     {
                         EstimatedTimeRemaining = TimeSpan.FromSeconds(remainingSeconds);
-                        EstimatedTimeCompletion = DateTime.Now.AddSeconds(remainingSeconds);
+                        EstimatedTimeCompletion = DateTime.UtcNow.AddSeconds(remainingSeconds);
                     }
                     OnPropertyChanged(nameof(EstimatedTimeRemaining));
                     OnPropertyChanged(nameof(EstimatedTimeCompletion));

--- a/src/S7Tools.Core/Models/Jobs/TaskExecution.cs
+++ b/src/S7Tools.Core/Models/Jobs/TaskExecution.cs
@@ -48,7 +48,7 @@ public class TaskExecution : INotifyPropertyChanged
     public TaskExecution(ITimeProvider timeProvider)
     {
         _timeProvider = timeProvider;
-        CreatedAt = _timeProvider.GetUtcNow();
+        CreatedAt = _timeProvider.GetLocalNow();
     }
 
     /// <summary>
@@ -61,9 +61,9 @@ public class TaskExecution : INotifyPropertyChanged
     }
 
     /// <summary>
-    /// Helper to get UTC now from provider or fallback.
+    /// Helper to get local now from provider or fallback.
     /// </summary>
-    private DateTime UtcNow => _timeProvider?.GetUtcNow() ?? DateTime.UtcNow;
+    private DateTime Now => _timeProvider?.GetLocalNow() ?? DateTime.Now;
 
     /// <summary>
     /// Event triggered when a property value changes.
@@ -134,7 +134,7 @@ public class TaskExecution : INotifyPropertyChanged
     /// <summary>
     /// Gets or sets the time when the task was created.
     /// </summary>
-    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime CreatedAt { get; set; } = DateTime.Now;
 
     /// <summary>
     /// Gets or sets the time when the task was queued for execution.
@@ -309,7 +309,7 @@ public class TaskExecution : INotifyPropertyChanged
     /// <summary>
     /// Gets the total time since the task was created.
     /// </summary>
-    public TimeSpan TotalTime => UtcNow - CreatedAt;
+    public TimeSpan TotalTime => Now - CreatedAt;
 
     /// <summary>
     /// Gets a value indicating whether the task is in a terminal state.
@@ -343,15 +343,15 @@ public class TaskExecution : INotifyPropertyChanged
         switch (newState)
         {
             case TaskState.Queued:
-                QueuedAt = UtcNow;
+                QueuedAt = Now;
                 break;
             case TaskState.Running:
-                StartedAt = UtcNow;
+                StartedAt = Now;
                 break;
             case TaskState.Completed:
             case TaskState.Failed:
             case TaskState.Cancelled:
-                CompletedAt = UtcNow;
+                CompletedAt = Now;
                 break;
         }
 
@@ -411,7 +411,7 @@ public class TaskExecution : INotifyPropertyChanged
             // Calculate Speed and ETC
             if (hasBytes && TotalBytes.HasValue && TotalBytes.Value > 0)
             {
-                var now = UtcNow;
+                var now = Now;
                 if (_lastProgressUpdate != DateTime.MinValue && now > _lastProgressUpdate)
                 {
                     double seconds = (now - _lastProgressUpdate).TotalSeconds;
@@ -448,7 +448,7 @@ public class TaskExecution : INotifyPropertyChanged
                     if (remainingSeconds < 86400)
                     {
                         EstimatedTimeRemaining = TimeSpan.FromSeconds(remainingSeconds);
-                        EstimatedTimeCompletion = UtcNow.AddSeconds(remainingSeconds);
+                        EstimatedTimeCompletion = Now.AddSeconds(remainingSeconds);
                     }
                     OnPropertyChanged(nameof(EstimatedTimeRemaining));
                     OnPropertyChanged(nameof(EstimatedTimeCompletion));

--- a/src/S7Tools.Core/Models/Jobs/TaskLogger.cs
+++ b/src/S7Tools.Core/Models/Jobs/TaskLogger.cs
@@ -76,7 +76,7 @@ public class TaskLogger
     /// <summary>
     /// Gets or sets the time when logging was initialized.
     /// </summary>
-    public DateTime CreatedAt { get; set; } = DateTime.Now;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
     /// <summary>
     /// Gets or sets the time when logging was finalized.

--- a/src/S7Tools.Core/Models/LogModel.cs
+++ b/src/S7Tools.Core/Models/LogModel.cs
@@ -15,7 +15,7 @@ public sealed record LogModel
     /// <summary>
     /// Gets the timestamp when the log entry was created.
     /// </summary>
-    public DateTime Timestamp { get; init; } = DateTime.Now;
+    public DateTime Timestamp { get; init; } = DateTime.UtcNow;
 
     /// <summary>
     /// Gets the log level (Information, Warning, Error, etc.).

--- a/src/S7Tools.Core/Services/Interfaces/ITimeProvider.cs
+++ b/src/S7Tools.Core/Services/Interfaces/ITimeProvider.cs
@@ -1,0 +1,18 @@
+namespace S7Tools.Core.Services.Interfaces;
+
+/// <summary>
+/// Provides an abstraction for retrieving the current date and time.
+/// Used to enable testability and consistency across the application.
+/// </summary>
+public interface ITimeProvider
+{
+    /// <summary>
+    /// Gets the current date and time in Coordinated Universal Time (UTC).
+    /// </summary>
+    DateTime GetUtcNow();
+
+    /// <summary>
+    /// Gets the current date and time expressed as the local time.
+    /// </summary>
+    DateTime GetLocalNow();
+}

--- a/src/S7Tools.Infrastructure.Logging/Providers/Extensions/LoggingServiceCollectionExtensions.cs
+++ b/src/S7Tools.Infrastructure.Logging/Providers/Extensions/LoggingServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using S7Tools.Infrastructure.Logging.Core.Configuration;
 using S7Tools.Infrastructure.Logging.Core.Models;
 using S7Tools.Infrastructure.Logging.Core.Storage;
 using S7Tools.Infrastructure.Logging.Providers.Microsoft;
+using S7Tools.Core.Services.Interfaces;
 
 namespace S7Tools.Infrastructure.Logging.Providers.Extensions;
 
@@ -54,7 +55,8 @@ public static class LoggingServiceCollectionExtensions
         {
             ILogDataStore dataStore = serviceProvider.GetRequiredService<ILogDataStore>();
             DataStoreLoggerConfiguration configuration = serviceProvider.GetRequiredService<DataStoreLoggerConfiguration>();
-            return new DataStoreLoggerProvider(dataStore, configuration);
+            ITimeProvider timeProvider = serviceProvider.GetRequiredService<ITimeProvider>();
+            return new DataStoreLoggerProvider(dataStore, timeProvider, configuration);
         });
 
         return services;
@@ -110,7 +112,8 @@ public static class LoggingServiceCollectionExtensions
         {
             ILogDataStore dataStore = serviceProvider.GetRequiredService<ILogDataStore>();
             DataStoreLoggerConfiguration configuration = serviceProvider.GetRequiredService<DataStoreLoggerConfiguration>();
-            return new DataStoreLoggerProvider(dataStore, configuration);
+            ITimeProvider timeProvider = serviceProvider.GetRequiredService<ITimeProvider>();
+            return new DataStoreLoggerProvider(dataStore, timeProvider, configuration);
         });
 
         return services;

--- a/src/S7Tools.Infrastructure.Logging/Providers/Microsoft/DataStoreLogger.cs
+++ b/src/S7Tools.Infrastructure.Logging/Providers/Microsoft/DataStoreLogger.cs
@@ -4,6 +4,7 @@ using S7Tools.Core.Models;
 using S7Tools.Infrastructure.Logging.Core.Configuration;
 using S7Tools.Infrastructure.Logging.Core.Models;
 using S7Tools.Infrastructure.Logging.Core.Storage;
+using S7Tools.Core.Services.Interfaces;
 
 namespace S7Tools.Infrastructure.Logging.Providers.Microsoft;
 
@@ -15,6 +16,7 @@ public sealed class DataStoreLogger : ILogger
     private readonly string _categoryName;
     private readonly ILogDataStore _dataStore;
     private readonly DataStoreLoggerConfiguration _configuration;
+    private readonly ITimeProvider _timeProvider;
 
     /// <summary>
     /// Initializes a new instance of the DataStoreLogger class.
@@ -22,11 +24,13 @@ public sealed class DataStoreLogger : ILogger
     /// <param name="categoryName">The category name for this logger.</param>
     /// <param name="dataStore">The data store to write log entries to.</param>
     /// <param name="configuration">The logger configuration.</param>
-    public DataStoreLogger(string categoryName, ILogDataStore dataStore, DataStoreLoggerConfiguration configuration)
+    /// <param name="timeProvider">The time provider for timestamp generation.</param>
+    public DataStoreLogger(string categoryName, ILogDataStore dataStore, DataStoreLoggerConfiguration configuration, ITimeProvider timeProvider)
     {
         _categoryName = categoryName ?? throw new ArgumentNullException(nameof(categoryName));
         _dataStore = dataStore ?? throw new ArgumentNullException(nameof(dataStore));
         _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
     }
 
     /// <inheritdoc />
@@ -65,7 +69,7 @@ public sealed class DataStoreLogger : ILogger
 
         var logEntry = new LogModel
         {
-            Timestamp = DateTime.UtcNow,
+            Timestamp = _timeProvider.GetLocalNow(),
             Level = logLevel,
             Category = _categoryName,
             Message = message,

--- a/src/S7Tools.Infrastructure.Logging/Providers/Microsoft/DataStoreLogger.cs
+++ b/src/S7Tools.Infrastructure.Logging/Providers/Microsoft/DataStoreLogger.cs
@@ -65,7 +65,7 @@ public sealed class DataStoreLogger : ILogger
 
         var logEntry = new LogModel
         {
-            Timestamp = DateTime.Now,
+            Timestamp = DateTime.UtcNow,
             Level = logLevel,
             Category = _categoryName,
             Message = message,

--- a/src/S7Tools.Infrastructure.Logging/Providers/Microsoft/DataStoreLoggerProvider.cs
+++ b/src/S7Tools.Infrastructure.Logging/Providers/Microsoft/DataStoreLoggerProvider.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using S7Tools.Infrastructure.Logging.Core.Configuration;
 using S7Tools.Infrastructure.Logging.Core.Storage;
+using S7Tools.Core.Services.Interfaces;
 
 namespace S7Tools.Infrastructure.Logging.Providers.Microsoft;
 
@@ -14,6 +15,7 @@ public sealed class DataStoreLoggerProvider : ILoggerProvider, ISupportExternalS
 {
     private readonly ILogDataStore _dataStore;
     private readonly DataStoreLoggerConfiguration _configuration;
+    private readonly ITimeProvider _timeProvider;
     private readonly ConcurrentDictionary<string, DataStoreLogger> _loggers = new();
     private IExternalScopeProvider? _scopeProvider;
     private bool _disposed;
@@ -23,21 +25,25 @@ public sealed class DataStoreLoggerProvider : ILoggerProvider, ISupportExternalS
     /// </summary>
     /// <param name="dataStore">The data store to write log entries to.</param>
     /// <param name="configuration">The logger configuration.</param>
-    public DataStoreLoggerProvider(ILogDataStore dataStore, DataStoreLoggerConfiguration? configuration = null)
+    /// <param name="timeProvider">The time provider for timestamp generation.</param>
+    public DataStoreLoggerProvider(ILogDataStore dataStore, ITimeProvider timeProvider, DataStoreLoggerConfiguration? configuration = null)
     {
         _dataStore = dataStore ?? throw new ArgumentNullException(nameof(dataStore));
         _configuration = configuration ?? new DataStoreLoggerConfiguration();
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
     }
 
     /// <summary>
     /// Initializes a new instance of the DataStoreLoggerProvider class with options.
     /// </summary>
     /// <param name="dataStore">The data store to write log entries to.</param>
+    /// <param name="timeProvider">The time provider for timestamp generation.</param>
     /// <param name="options">The logger configuration options.</param>
-    public DataStoreLoggerProvider(ILogDataStore dataStore, IOptionsMonitor<DataStoreLoggerConfiguration> options)
+    public DataStoreLoggerProvider(ILogDataStore dataStore, ITimeProvider timeProvider, IOptionsMonitor<DataStoreLoggerConfiguration> options)
     {
         _dataStore = dataStore ?? throw new ArgumentNullException(nameof(dataStore));
         _configuration = options?.CurrentValue ?? new DataStoreLoggerConfiguration();
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
 
         // Monitor configuration changes
         options?.OnChange(config =>
@@ -59,7 +65,7 @@ public sealed class DataStoreLoggerProvider : ILoggerProvider, ISupportExternalS
             throw new ObjectDisposedException(nameof(DataStoreLoggerProvider));
         }
 
-        return _loggers.GetOrAdd(categoryName, name => new DataStoreLogger(name, _dataStore, _configuration));
+        return _loggers.GetOrAdd(categoryName, name => new DataStoreLogger(name, _dataStore, _configuration, _timeProvider));
     }
 
     /// <inheritdoc />

--- a/src/S7Tools.Infrastructure.Logging/Providers/Microsoft/UnifiedLogger.cs
+++ b/src/S7Tools.Infrastructure.Logging/Providers/Microsoft/UnifiedLogger.cs
@@ -45,7 +45,7 @@ public class UnifiedLogger : ILogger
 
         var message = formatter(state, exception);
         var logEntry = new LogEntry(
-            DateTime.Now,
+            DateTime.UtcNow,
             logLevel,
             _categoryName,
             message,

--- a/src/S7Tools/Extensions/ServiceCollectionExtensions.cs
+++ b/src/S7Tools/Extensions/ServiceCollectionExtensions.cs
@@ -45,6 +45,9 @@ public static class ServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
 
+        // Add Time Provider - Critical for testability and consistency
+        services.TryAddSingleton<ITimeProvider, S7Tools.Services.Time.TimeProvider>();
+
         // Add UI Thread Service
         services.TryAddSingleton<IUIThreadService, AvaloniaUIThreadService>();
 
@@ -124,7 +127,8 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<ISerialPortService>(provider =>
             new SerialPortService(
                 provider.GetRequiredService<ILogger<SerialPortService>>(),
-                provider.GetRequiredService<IApplicationSettingsService>()
+                provider.GetRequiredService<IApplicationSettingsService>(),
+                provider.GetRequiredService<ITimeProvider>()
             )
         );
 
@@ -137,7 +141,8 @@ public static class ServiceCollectionExtensions
             new SocatService(
                 provider.GetRequiredService<ILogger<SocatService>>(),
                 provider.GetRequiredService<IApplicationSettingsService>(),
-                provider.GetRequiredService<ISerialPortService>()
+                provider.GetRequiredService<ISerialPortService>(),
+                provider.GetRequiredService<ITimeProvider>()
             )
         );
 
@@ -273,6 +278,7 @@ public static class ServiceCollectionExtensions
             ISocatProfileService socatProfileService = serviceProvider.GetRequiredService<ISocatProfileService>();
             IPowerSupplyProfileService powerSupplyProfileService = serviceProvider.GetRequiredService<IPowerSupplyProfileService>();
             IMemoryRegionProfileService memoryRegionProfileService = serviceProvider.GetRequiredService<IMemoryRegionProfileService>();
+            ITimeProvider timeProvider = serviceProvider.GetRequiredService<ITimeProvider>();
 
 
             // Create options with dynamically resolved path
@@ -281,7 +287,7 @@ public static class ServiceCollectionExtensions
                 ProfilesPath = pathService.JobsPath
             });
 
-            return new JobManager(options, logger, resourceCoordinator, serialProfileService, socatProfileService, powerSupplyProfileService, memoryRegionProfileService);
+            return new JobManager(options, logger, resourceCoordinator, serialProfileService, socatProfileService, powerSupplyProfileService, memoryRegionProfileService, timeProvider);
         });
 
         // Add JobProfileSetFactory for creating JobProfileSet from profile IDs

--- a/src/S7Tools/Services/Adapters/Plc/PlcProtocolHandler.cs
+++ b/src/S7Tools/Services/Adapters/Plc/PlcProtocolHandler.cs
@@ -55,13 +55,15 @@ namespace S7Tools.Services.Adapters.Plc
 
         public async Task PerformHandshakeAsync(CancellationToken cancellationToken)
         {
+            const int MaxHandshakeAttempts = 50; // Maximum attempts before giving up
+
             byte[] magic = System.Text.Encoding.ASCII.GetBytes("MFGT1");
             byte[] padding = System.Text.Encoding.ASCII.GetBytes("AAAA");
             byte[] handshakePayload = new byte[padding.Length + magic.Length];
             Array.Copy(padding, 0, handshakePayload, 0, padding.Length);
             Array.Copy(magic, 0, handshakePayload, padding.Length, magic.Length);
 
-            for (int attempt = 0; attempt < 50; attempt++)
+            for (int attempt = 0; attempt < MaxHandshakeAttempts; attempt++)
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 await _protocol.RawWriteAsync(handshakePayload, 0, handshakePayload.Length, cancellationToken);
@@ -89,7 +91,7 @@ namespace S7Tools.Services.Adapters.Plc
                 }
                 await Task.Delay(10, cancellationToken);
             }
-            throw new Exception("Handshake failed after 100 attempts");
+            throw new Exception($"Handshake failed after {MaxHandshakeAttempts} attempts");
         }
 
         public async Task<byte[]> GetVersionAsync(CancellationToken cancellationToken)

--- a/src/S7Tools/Services/Bootloader/BootloaderService.cs
+++ b/src/S7Tools/Services/Bootloader/BootloaderService.cs
@@ -207,13 +207,14 @@ public sealed class BootloaderService(
                 // Decomposed Power Cycle for progress reporting
                 await _power.TurnOffAsync(effectiveTaskLogger, cancellationToken).ConfigureAwait(false);
 
-                await WaitWithProgressAsync(
+                //Keep this commented
+                /*await WaitWithProgressAsync(
                     profiles.PowerOffDelayMs,
                     progress,
                     20.0, 25.0,
                     "power_cycle",
                     cancellationToken).ConfigureAwait(false);
-
+                */
                 await _power.TurnOnAsync(effectiveTaskLogger, cancellationToken).ConfigureAwait(false);
 
                 effectiveTaskLogger.LogInformation("✓ PLC power cycled successfully (Client already connected)");

--- a/src/S7Tools/Services/Bootloader/BootloaderService.cs
+++ b/src/S7Tools/Services/Bootloader/BootloaderService.cs
@@ -17,6 +17,7 @@ public sealed class BootloaderService(
     ISocatService socat,
     IPowerSupplyService power,
     ISerialPortService serialPort,
+    ITimeProvider timeProvider,
     Func<JobProfileSet, IPlcClient> clientFactory) : IBootloaderService
 {
     private readonly ILogger<BootloaderService> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -25,6 +26,7 @@ public sealed class BootloaderService(
     private readonly IPowerSupplyService _power = power ?? throw new ArgumentNullException(nameof(power));
     private readonly ISerialPortService _serialPort = serialPort ?? throw new ArgumentNullException(nameof(serialPort));
     private readonly Func<JobProfileSet, IPlcClient> _clientFactory = clientFactory ?? throw new ArgumentNullException(nameof(clientFactory));
+    private readonly ITimeProvider _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
 
     private const int InitialPowerOffWaitMs = 10000;
 
@@ -272,8 +274,7 @@ public sealed class BootloaderService(
                         cancellationToken).ConfigureAwait(false);
 
                     effectiveTaskLogger.LogDebug("Memory dumper payload loaded: {Size} bytes", dumperPayload.Length);
-
-                    DateTime dumpStartTime = DateTime.UtcNow;
+                    DateTime dumpStartTime = _timeProvider.GetUtcNow();
 
                     for (int i = 0; i < selectedSegments.Count; i++)
                     {
@@ -317,7 +318,7 @@ public sealed class BootloaderService(
                             }
                         });
 
-                        DateTime segmentStartTime = DateTime.UtcNow;
+                        DateTime segmentStartTime = _timeProvider.GetUtcNow();
                         byte[] segmentData = await client.DumpMemoryAsync(
                             segmentStart,
                             segmentSize,
@@ -325,7 +326,7 @@ public sealed class BootloaderService(
                             segmentProgress,
                             cancellationToken).ConfigureAwait(false);
 
-                        TimeSpan segmentDuration = DateTime.UtcNow - segmentStartTime;
+                        TimeSpan segmentDuration = _timeProvider.GetUtcNow() - segmentStartTime;
                         double transferRate = segmentData.Length / segmentDuration.TotalSeconds;
 
                         segmentDataList.Add(segmentData);
@@ -337,7 +338,7 @@ public sealed class BootloaderService(
 
                     // Concatenate all segment data
                     memoryData = [.. segmentDataList.SelectMany(arr => arr)];
-                    TimeSpan totalDuration = DateTime.UtcNow - dumpStartTime;
+                    TimeSpan totalDuration = _timeProvider.GetUtcNow() - dumpStartTime;
                     double overallRate = memoryData.Length / totalDuration.TotalSeconds;
 
                     effectiveTaskLogger.LogInformation("✓ Multi-segment dump completed: {TotalSegments} segments, {TotalSize:N0} bytes",
@@ -394,7 +395,7 @@ public sealed class BootloaderService(
                         }
                     });
 
-                    DateTime dumpStartTime = DateTime.UtcNow;
+                    DateTime dumpStartTime = _timeProvider.GetUtcNow();
                     memoryData = await client.DumpMemoryAsync(
                         profiles.Memory.Start,
                         profiles.Memory.Length,
@@ -402,7 +403,7 @@ public sealed class BootloaderService(
                         dumpProgress,
                         cancellationToken).ConfigureAwait(false);
 
-                    TimeSpan dumpDuration = DateTime.UtcNow - dumpStartTime;
+                    TimeSpan dumpDuration = _timeProvider.GetUtcNow() - dumpStartTime;
                     double transferRate = memoryData.Length > 0 && dumpDuration.TotalSeconds > 0 ? memoryData.Length / dumpDuration.TotalSeconds : 0;
 
                     effectiveTaskLogger.LogInformation("✓ Memory dump completed: {Size:N0} bytes from 0x{Start:X8}",

--- a/src/S7Tools/Services/Bootloader/BootloaderService.cs
+++ b/src/S7Tools/Services/Bootloader/BootloaderService.cs
@@ -207,13 +207,13 @@ public sealed class BootloaderService(
                 // Decomposed Power Cycle for progress reporting
                 await _power.TurnOffAsync(effectiveTaskLogger, cancellationToken).ConfigureAwait(false);
 
-                /*await WaitWithProgressAsync(
+                await WaitWithProgressAsync(
                     profiles.PowerOffDelayMs,
                     progress,
                     20.0, 25.0,
                     "power_cycle",
                     cancellationToken).ConfigureAwait(false);
-                */
+
                 await _power.TurnOnAsync(effectiveTaskLogger, cancellationToken).ConfigureAwait(false);
 
                 effectiveTaskLogger.LogInformation("✓ PLC power cycled successfully (Client already connected)");

--- a/src/S7Tools/Services/Bootloader/BootloaderService.cs
+++ b/src/S7Tools/Services/Bootloader/BootloaderService.cs
@@ -437,7 +437,7 @@ public sealed class BootloaderService(
         catch (Exception ex)
         {
             _logger.LogError(ex, "Bootloader dump operation failed: {ErrorMessage}", ex.Message);
-            effectiveTaskLogger?.LogError("❌ DUMP OPERATION FAILED: {ErrorMessage}", ex.Message);
+            effectiveTaskLogger?.LogError("DUMP OPERATION FAILED: {ErrorMessage}", ex.Message);
             effectiveTaskLogger?.LogError("Exception type: {ExceptionType}", ex.GetType().Name);
             throw;
         }

--- a/src/S7Tools/Services/Bootloader/EnhancedBootloaderService.cs
+++ b/src/S7Tools/Services/Bootloader/EnhancedBootloaderService.cs
@@ -864,7 +864,7 @@ public sealed class EnhancedBootloaderService(
             Directory.CreateDirectory(outputPath);
 
             // Generate filename with timestamp and task ID
-            string timestamp = DateTime.Now.ToString(DateTimeFormats.FileTimestamp);
+            string timestamp = DateTime.UtcNow.ToLocalTime().ToString(DateTimeFormats.FileTimestamp);
             string fileName = $"memory_dump_{timestamp}_{taskId:N}.bin";
             string filePath = Path.Combine(outputPath, fileName);
 

--- a/src/S7Tools/Services/Jobs/JobManager.cs
+++ b/src/S7Tools/Services/Jobs/JobManager.cs
@@ -27,7 +27,8 @@ public class JobManager(
     ISerialPortProfileService serialProfileService,
     ISocatProfileService socatProfileService,
     IPowerSupplyProfileService powerSupplyProfileService,
-    IMemoryRegionProfileService memoryRegionProfileService)
+    IMemoryRegionProfileService memoryRegionProfileService,
+    ITimeProvider timeProvider)
     : StandardProfileManager<JobProfile>(options.Value.ProfilesPath, logger), IJobManager
 {
     #region Private Fields
@@ -37,6 +38,7 @@ public class JobManager(
     private readonly ISocatProfileService _socatProfileService = socatProfileService ?? throw new ArgumentNullException(nameof(socatProfileService));
     private readonly IPowerSupplyProfileService _powerSupplyProfileService = powerSupplyProfileService ?? throw new ArgumentNullException(nameof(powerSupplyProfileService));
     private readonly IMemoryRegionProfileService _memoryRegionProfileService = memoryRegionProfileService ?? throw new ArgumentNullException(nameof(memoryRegionProfileService));
+    private readonly ITimeProvider _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
 
 
     #endregion
@@ -136,8 +138,8 @@ public class JobManager(
 
             // Assign ID and add to collection
             newJob.Id = GetNextAvailableIdCore();
-            newJob.CreatedAt = DateTime.UtcNow;
-            newJob.ModifiedAt = DateTime.UtcNow;
+            newJob.CreatedAt = _timeProvider.GetUtcNow();
+            newJob.ModifiedAt = _timeProvider.GetUtcNow();
 
             _profiles.Add(newJob);
             _profiles.Sort((x, y) => x.Id.CompareTo(y.Id));
@@ -168,8 +170,8 @@ public class JobManager(
 
             // Assign ID and add to collection
             job.Id = GetNextAvailableIdCore();
-            job.CreatedAt = DateTime.UtcNow;
-            job.ModifiedAt = DateTime.UtcNow;
+            job.CreatedAt = _timeProvider.GetUtcNow();
+            job.ModifiedAt = _timeProvider.GetUtcNow();
 
             _profiles.Add(job);
             _profiles.Sort((x, y) => x.Id.CompareTo(y.Id));
@@ -639,8 +641,8 @@ public class JobManager(
             Description = jobProfile.Description ?? string.Empty,
             ProfileSet = profileSet,
             State = JobState.Created,
-            CreatedAt = DateTime.UtcNow,
-            ModifiedAt = DateTime.UtcNow,
+            CreatedAt = _timeProvider.GetUtcNow(),
+            ModifiedAt = _timeProvider.GetUtcNow(),
             Progress = 0.0,
             CurrentOperation = string.Empty,
             OutputPath = jobProfile.OutputPath ?? string.Empty

--- a/src/S7Tools/Services/Jobs/JobManager.cs
+++ b/src/S7Tools/Services/Jobs/JobManager.cs
@@ -138,8 +138,8 @@ public class JobManager(
 
             // Assign ID and add to collection
             newJob.Id = GetNextAvailableIdCore();
-            newJob.CreatedAt = _timeProvider.GetUtcNow();
-            newJob.ModifiedAt = _timeProvider.GetUtcNow();
+            newJob.CreatedAt = _timeProvider.GetLocalNow();
+            newJob.ModifiedAt = _timeProvider.GetLocalNow();
 
             _profiles.Add(newJob);
             _profiles.Sort((x, y) => x.Id.CompareTo(y.Id));
@@ -170,8 +170,8 @@ public class JobManager(
 
             // Assign ID and add to collection
             job.Id = GetNextAvailableIdCore();
-            job.CreatedAt = _timeProvider.GetUtcNow();
-            job.ModifiedAt = _timeProvider.GetUtcNow();
+            job.CreatedAt = _timeProvider.GetLocalNow();
+            job.ModifiedAt = _timeProvider.GetLocalNow();
 
             _profiles.Add(job);
             _profiles.Sort((x, y) => x.Id.CompareTo(y.Id));
@@ -641,8 +641,8 @@ public class JobManager(
             Description = jobProfile.Description ?? string.Empty,
             ProfileSet = profileSet,
             State = JobState.Created,
-            CreatedAt = _timeProvider.GetUtcNow(),
-            ModifiedAt = _timeProvider.GetUtcNow(),
+            CreatedAt = _timeProvider.GetLocalNow(),
+            ModifiedAt = _timeProvider.GetLocalNow(),
             Progress = 0.0,
             CurrentOperation = string.Empty,
             OutputPath = jobProfile.OutputPath ?? string.Empty

--- a/src/S7Tools/Services/LogExportService.cs
+++ b/src/S7Tools/Services/LogExportService.cs
@@ -147,7 +147,7 @@ public class LogExportService : ILogExportService
     /// <inheritdoc/>
     public string GenerateDefaultFileName(ExportFormat format)
     {
-        string timestamp = DateTime.Now.ToString(DateTimeFormats.FileTimestamp);
+        string timestamp = DateTime.UtcNow.ToLocalTime().ToString(DateTimeFormats.FileTimestamp);
         string extension = format switch
         {
             ExportFormat.Text => "txt",
@@ -168,13 +168,13 @@ public class LogExportService : ILogExportService
     {
         var sb = new StringBuilder();
         sb.AppendLine("S7Tools Log Export");
-        sb.AppendLine($"Generated: {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
+        sb.AppendLine($"Generated: {DateTime.UtcNow.ToLocalTime():yyyy-MM-dd HH:mm:ss}");
         sb.AppendLine(new string('=', 80));
         sb.AppendLine();
 
         foreach (LogModel? log in logs.OrderBy(l => l.Timestamp))
         {
-            sb.AppendLine($"[{log.Timestamp:yyyy-MM-dd HH:mm:ss.fff}] [{log.Level}] {log.Category}");
+            sb.AppendLine($"[{log.Timestamp.ToLocalTime():yyyy-MM-dd HH:mm:ss.fff}] [{log.Level}] {log.Category}");
             sb.AppendLine($"Message: {log.FormattedMessage}");
 
             if (log.Exception != null)
@@ -202,7 +202,7 @@ public class LogExportService : ILogExportService
             ExportInfo = new
             {
                 Application = "S7Tools",
-                ExportDate = DateTime.UtcNow,
+                ExportDate = DateTime.UtcNow.ToLocalTime(),
                 TotalEntries = logs.Count()
             },
             Logs = logs
@@ -210,7 +210,7 @@ public class LogExportService : ILogExportService
                 .Select(log => new
                 {
                     Id = log.Id,
-                    Timestamp = log.Timestamp, // Serialized as ISO 8601
+                    Timestamp = log.Timestamp.ToLocalTime(), // Serialized as ISO 8601 (Local)
                     Level = log.Level.ToString(),
                     Category = log.Category,
                     Message = log.Message,
@@ -249,7 +249,7 @@ public class LogExportService : ILogExportService
         // CSV Data
         foreach (LogModel? log in logs.OrderBy(l => l.Timestamp))
         {
-            string timestamp = log.Timestamp.ToString(DateTimeFormats.MillisecondDateTime);
+            string timestamp = log.Timestamp.ToLocalTime().ToString(DateTimeFormats.MillisecondDateTime);
             string level = log.Level.ToString();
             string category = EscapeCsvField(log.Category);
             string message = EscapeCsvField(log.FormattedMessage);

--- a/src/S7Tools/Services/LogExportService.cs
+++ b/src/S7Tools/Services/LogExportService.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using S7Tools.Core.Constants;
 using S7Tools.Core.Interfaces.Services;
 using S7Tools.Core.Models;
+using S7Tools.Core.Services.Interfaces;
 using S7Tools.Infrastructure.Logging.Core.Models;
 using S7Tools.Services.Interfaces;
 
@@ -21,6 +22,7 @@ public class LogExportService : ILogExportService
 {
     private readonly ILogger<LogExportService> _logger;
     private readonly IPathService _pathService;
+    private readonly ITimeProvider _timeProvider;
     private readonly string _defaultExportPath;
 
     /// <summary>
@@ -28,10 +30,12 @@ public class LogExportService : ILogExportService
     /// </summary>
     /// <param name="logger">The logger instance.</param>
     /// <param name="pathService">The path service for resolving export paths.</param>
-    public LogExportService(ILogger<LogExportService> logger, IPathService pathService)
+    /// <param name="timeProvider">The time provider for file timestamp generation.</param>
+    public LogExportService(ILogger<LogExportService> logger, IPathService pathService, ITimeProvider timeProvider)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _pathService = pathService ?? throw new ArgumentNullException(nameof(pathService));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
 
         // Use the dynamic path service for export path resolution
         _defaultExportPath = _pathService.ExportedLogsDirectory;
@@ -147,7 +151,7 @@ public class LogExportService : ILogExportService
     /// <inheritdoc/>
     public string GenerateDefaultFileName(ExportFormat format)
     {
-        string timestamp = DateTime.UtcNow.ToLocalTime().ToString(DateTimeFormats.FileTimestamp);
+        string timestamp = _timeProvider.GetLocalNow().ToString(DateTimeFormats.FileTimestamp);
         string extension = format switch
         {
             ExportFormat.Text => "txt",
@@ -168,7 +172,7 @@ public class LogExportService : ILogExportService
     {
         var sb = new StringBuilder();
         sb.AppendLine("S7Tools Log Export");
-        sb.AppendLine($"Generated: {DateTime.UtcNow.ToLocalTime():yyyy-MM-dd HH:mm:ss}");
+        sb.AppendLine($"Generated: {_timeProvider.GetLocalNow():yyyy-MM-dd HH:mm:ss}");
         sb.AppendLine(new string('=', 80));
         sb.AppendLine();
 
@@ -202,7 +206,7 @@ public class LogExportService : ILogExportService
             ExportInfo = new
             {
                 Application = "S7Tools",
-                ExportDate = DateTime.UtcNow.ToLocalTime(),
+                ExportDate = _timeProvider.GetLocalNow(),
                 TotalEntries = logs.Count()
             },
             Logs = logs

--- a/src/S7Tools/Services/Logging/TaskLoggerFactory.cs
+++ b/src/S7Tools/Services/Logging/TaskLoggerFactory.cs
@@ -40,131 +40,160 @@ public class TaskLoggerFactory(IPathService pathService, ILogger<TaskLoggerFacto
                 return existingLogger.TaskLogger;
             }
 
-            // Create log directory for this task
-            string sanitizedTaskName = SanitizeFileName(taskName);
-            string timestamp = DateTime.UtcNow.ToLocalTime().ToString("yyyyMMdd_HHmmss");
-            string taskLogDir = Path.Combine(
-                _pathService.LogsDirectory,
-                "Tasks",
-                $"{sanitizedTaskName}_{timestamp}_{taskId.ToString()[..8]}");
+            DataStoreLoggerProvider? mainProvider = null;
+            DataStoreLoggerProvider? protocolProvider = null;
+            DataStoreLoggerProvider? processProvider = null;
+            var fileLoggers = new List<ILogger>();
 
-            Directory.CreateDirectory(taskLogDir);
-
-            // Get shared DataStores from CentralizedTaskLogService
-            (ITaskLogDataStore mainDataStore, ITaskLogDataStore processDataStore, ITaskLogDataStore protocolDataStore) = _centralizedTaskLogService.GetOrCreateStoresForTask(taskId);
-
-            // Cast to LogDataStore for use with providers
-            var mainLogDataStore = (LogDataStore)mainDataStore;
-            LogDataStore? processLogDataStore = captureProcessOutput ? (LogDataStore?)processDataStore : null;
-            LogDataStore? protocolLogDataStore = captureProtocol ? (LogDataStore?)protocolDataStore : null;
-
-            // Create logger providers with DataStores
-            // Get configured log level from application settings (default to Information if not set or invalid)
-            string logLevelString = _applicationSettingsService.GetSetting<string>("logging.level", "Information");
-
-
-
-            if (!Enum.TryParse(logLevelString, true, out LogLevel configuredLogLevel))
+            try
             {
-                configuredLogLevel = LogLevel.Information;
+                // Create log directory for this task
+                string sanitizedTaskName = SanitizeFileName(taskName);
+                string timestamp = DateTime.UtcNow.ToLocalTime().ToString("yyyyMMdd_HHmmss");
+                string taskLogDir = Path.Combine(
+                    _pathService.LogsDirectory,
+                    "Tasks",
+                    $"{sanitizedTaskName}_{timestamp}_{taskId.ToString()[..8]}");
+
+                Directory.CreateDirectory(taskLogDir);
+
+                // Get shared DataStores from CentralizedTaskLogService
+                (ITaskLogDataStore mainDataStore, ITaskLogDataStore processDataStore, ITaskLogDataStore protocolDataStore) = _centralizedTaskLogService.GetOrCreateStoresForTask(taskId);
+
+                // Cast to LogDataStore for use with providers
+                var mainLogDataStore = (LogDataStore)mainDataStore;
+                LogDataStore? processLogDataStore = captureProcessOutput ? (LogDataStore?)processDataStore : null;
+                LogDataStore? protocolLogDataStore = captureProtocol ? (LogDataStore?)protocolDataStore : null;
+
+                // Create logger providers with DataStores
+                string logLevelString = _applicationSettingsService.GetSetting<string>("logging.level", "Information");
+
+                if (!Enum.TryParse(logLevelString, true, out LogLevel configuredLogLevel))
+                {
+                    configuredLogLevel = LogLevel.Information;
+                }
+
+                var mainConfig = new DataStoreLoggerConfiguration
+                {
+                    LogLevel = configuredLogLevel,
+                    IncludeScopes = true,
+                    CaptureProperties = true
+                };
+
+                var protocolConfig = new DataStoreLoggerConfiguration
+                {
+                    LogLevel = configuredLogLevel,
+                    IncludeScopes = true,
+                    CaptureProperties = true
+                };
+
+                mainProvider = new DataStoreLoggerProvider(mainLogDataStore, mainConfig);
+                protocolProvider = protocolLogDataStore != null
+                    ? new DataStoreLoggerProvider(protocolLogDataStore, protocolConfig)
+                    : null;
+                processProvider = processLogDataStore != null
+                    ? new DataStoreLoggerProvider(processLogDataStore, mainConfig)
+                    : null;
+
+                // Create file logger providers
+                ILogger mainFileLogger = await CreateFileLoggerAsync(
+                    Path.Combine(taskLogDir, "main.log"),
+                    configuredLogLevel).ConfigureAwait(false);
+                fileLoggers.Add(mainFileLogger);
+
+                ILogger? protocolFileLogger = null;
+                if (captureProtocol)
+                {
+                    protocolFileLogger = await CreateFileLoggerAsync(
+                        Path.Combine(taskLogDir, "protocol.log"),
+                        configuredLogLevel).ConfigureAwait(false);
+                    fileLoggers.Add(protocolFileLogger);
+                }
+
+                ILogger? processFileLogger = null;
+                if (captureProcessOutput)
+                {
+                    processFileLogger = await CreateFileLoggerAsync(
+                        Path.Combine(taskLogDir, "process.log"),
+                        configuredLogLevel).ConfigureAwait(false);
+                    fileLoggers.Add(processFileLogger);
+                }
+
+                // Create composite loggers
+                var mainLogger = new CompositeLogger(
+                    [.. new[] { mainProvider.CreateLogger($"Task.{taskName}"), mainFileLogger }.Where(l => l != null)]);
+
+                CompositeLogger? protocolLogger = captureProtocol
+                    ? new CompositeLogger(
+                        new[] { protocolProvider?.CreateLogger($"Task.{taskName}.Protocol"), protocolFileLogger }
+                            .Where(l => l != null).ToArray()!)
+                    : null;
+
+                CompositeLogger? processLogger = captureProcessOutput
+                    ? new CompositeLogger(
+                        new[] { processProvider?.CreateLogger($"Task.{taskName}.Process"), processFileLogger }
+                            .Where(l => l != null).ToArray()!)
+                    : null;
+
+                // Create TaskLogger metadata
+                var taskLogger = new TaskLogger
+                {
+                    TaskId = taskId,
+                    MainLogger = mainLogger,
+                    ProtocolLogger = protocolLogger,
+                    ProcessLogger = processLogger,
+                    MainLogDataStoreId = mainDataStore.GetHashCode().ToString(),
+                    ProtocolLogDataStoreId = protocolDataStore?.GetHashCode().ToString(),
+                    ProcessLogDataStoreId = processDataStore?.GetHashCode().ToString(),
+                    MainLogFilePath = Path.Combine(taskLogDir, "main.log"),
+                    ProtocolLogFilePath = captureProtocol ? Path.Combine(taskLogDir, "protocol.log") : null,
+                    ProcessLogFilePath = captureProcessOutput ? Path.Combine(taskLogDir, "process.log") : null,
+                    CaptureProtocol = captureProtocol,
+                    CaptureProcessOutput = captureProcessOutput,
+                    CreatedAt = DateTime.UtcNow
+                };
+
+                // Store context for cleanup
+                var context = new TaskLoggerContext
+                {
+                    TaskLogger = taskLogger,
+                    MainDataStore = mainLogDataStore,
+                    ProtocolDataStore = protocolLogDataStore,
+                    ProcessDataStore = processLogDataStore,
+                    MainProvider = mainProvider,
+                    ProtocolProvider = protocolProvider,
+                    ProcessProvider = processProvider,
+                    FileLoggers = [.. fileLoggers],
+                    LogDirectory = taskLogDir
+                };
+
+                _activeLoggers[taskId] = context;
+
+                _logger.LogInformation(
+                    "Created task logger for {TaskName} ({TaskId}) at {LogDir}",
+                    taskName, taskId, taskLogDir);
+
+                return taskLogger;
             }
-
-            var mainConfig = new DataStoreLoggerConfiguration
+            catch (Exception ex)
             {
-                LogLevel = configuredLogLevel,
-                IncludeScopes = true,
-                CaptureProperties = true
-            };
+                _logger.LogError(ex, "Failed to create task logger for {TaskName} ({TaskId})", taskName, taskId);
 
-            var protocolConfig = new DataStoreLoggerConfiguration
-            {
-                LogLevel = configuredLogLevel,
-                IncludeScopes = true,
-                CaptureProperties = true
-            };
+                // Cleanup partially created resources
+                mainProvider?.Dispose();
+                protocolProvider?.Dispose();
+                processProvider?.Dispose();
 
-            var mainProvider = new DataStoreLoggerProvider(mainLogDataStore, mainConfig);
-            DataStoreLoggerProvider? protocolProvider = protocolLogDataStore != null
-                ? new DataStoreLoggerProvider(protocolLogDataStore, protocolConfig)
-                : null;
-            DataStoreLoggerProvider? processProvider = processLogDataStore != null
-                ? new DataStoreLoggerProvider(processLogDataStore, mainConfig)
-                : null;
+                foreach (ILogger fileLogger in fileLoggers)
+                {
+                    if (fileLogger is IDisposable disposable)
+                    {
+                        disposable.Dispose();
+                    }
+                }
 
-            // Create file logger providers
-            ILogger mainFileLogger = await CreateFileLoggerAsync(
-                Path.Combine(taskLogDir, "main.log"),
-                configuredLogLevel).ConfigureAwait(false);
-
-            ILogger? protocolFileLogger = captureProtocol
-                ? await CreateFileLoggerAsync(
-                    Path.Combine(taskLogDir, "protocol.log"),
-                    configuredLogLevel).ConfigureAwait(false)
-                : null;
-
-            ILogger? processFileLogger = captureProcessOutput
-                ? await CreateFileLoggerAsync(
-                    Path.Combine(taskLogDir, "process.log"),
-                    configuredLogLevel).ConfigureAwait(false)
-                : null;
-
-            // Create composite loggers
-            // Create composite loggers
-            var mainLogger = new CompositeLogger(
-                [.. new[] { mainProvider.CreateLogger($"Task.{taskName}"), mainFileLogger }.Where(l => l != null)]);
-
-            CompositeLogger? protocolLogger = captureProtocol
-                ? new CompositeLogger(
-                    new[] { protocolProvider?.CreateLogger($"Task.{taskName}.Protocol"), protocolFileLogger }
-                        .Where(l => l != null).ToArray()!)
-                : null;
-
-            CompositeLogger? processLogger = captureProcessOutput
-                ? new CompositeLogger(
-                    new[] { processProvider?.CreateLogger($"Task.{taskName}.Process"), processFileLogger }
-                        .Where(l => l != null).ToArray()!)
-                : null;
-
-            // Create TaskLogger metadata
-            var taskLogger = new TaskLogger
-            {
-                TaskId = taskId,
-                MainLogger = mainLogger,
-                ProtocolLogger = protocolLogger,
-                ProcessLogger = processLogger,
-                MainLogDataStoreId = mainDataStore.GetHashCode().ToString(),
-                ProtocolLogDataStoreId = protocolDataStore?.GetHashCode().ToString(),
-                ProcessLogDataStoreId = processDataStore?.GetHashCode().ToString(),
-                MainLogFilePath = Path.Combine(taskLogDir, "main.log"),
-                ProtocolLogFilePath = captureProtocol ? Path.Combine(taskLogDir, "protocol.log") : null,
-                ProcessLogFilePath = captureProcessOutput ? Path.Combine(taskLogDir, "process.log") : null,
-                CaptureProtocol = captureProtocol,
-                CaptureProcessOutput = captureProcessOutput,
-                CreatedAt = DateTime.UtcNow
-            };
-
-            // Store context for cleanup
-            var context = new TaskLoggerContext
-            {
-                TaskLogger = taskLogger,
-                MainDataStore = mainLogDataStore,
-                ProtocolDataStore = protocolLogDataStore,
-                ProcessDataStore = processLogDataStore,
-                MainProvider = mainProvider,
-                ProtocolProvider = protocolProvider,
-                ProcessProvider = processProvider,
-                FileLoggers = new[] { mainFileLogger, protocolFileLogger, processFileLogger }
-                    .Where(l => l != null).ToList()!,
-                LogDirectory = taskLogDir
-            };
-
-            _activeLoggers[taskId] = context;
-
-            _logger.LogInformation(
-                "Created task logger for {TaskName} ({TaskId}) at {LogDir}",
-                taskName, taskId, taskLogDir);
-
-            return taskLogger;
+                throw;
+            }
         }, cancellationToken);
     }
 

--- a/src/S7Tools/Services/Logging/TaskLoggerFactory.cs
+++ b/src/S7Tools/Services/Logging/TaskLoggerFactory.cs
@@ -14,12 +14,13 @@ namespace S7Tools.Services.Logging;
 /// <summary>
 /// Factory for creating task-specific loggers with dedicated DataStores and file outputs.
 /// </summary>
-public class TaskLoggerFactory(IPathService pathService, ILogger<TaskLoggerFactory> logger, S7Tools.Core.Services.Interfaces.ICentralizedTaskLogService centralizedTaskLogService, IApplicationSettingsService applicationSettingsService) : ITaskLoggerFactory, IDisposable
+public class TaskLoggerFactory(IPathService pathService, ILogger<TaskLoggerFactory> logger, S7Tools.Core.Services.Interfaces.ICentralizedTaskLogService centralizedTaskLogService, IApplicationSettingsService applicationSettingsService, ITimeProvider timeProvider) : ITaskLoggerFactory, IDisposable
 {
     private readonly IPathService _pathService = pathService ?? throw new ArgumentNullException(nameof(pathService));
     private readonly ILogger<TaskLoggerFactory> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     private readonly S7Tools.Core.Services.Interfaces.ICentralizedTaskLogService _centralizedTaskLogService = centralizedTaskLogService ?? throw new ArgumentNullException(nameof(centralizedTaskLogService));
     private readonly IApplicationSettingsService _applicationSettingsService = applicationSettingsService ?? throw new ArgumentNullException(nameof(applicationSettingsService));
+    private readonly ITimeProvider _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
     private readonly ConcurrentDictionary<Guid, TaskLoggerContext> _activeLoggers = new();
     private readonly SemaphoreSlim _semaphore = new(1, 1);
     private bool _disposed;
@@ -49,7 +50,7 @@ public class TaskLoggerFactory(IPathService pathService, ILogger<TaskLoggerFacto
             {
                 // Create log directory for this task
                 string sanitizedTaskName = SanitizeFileName(taskName);
-                string timestamp = DateTime.UtcNow.ToLocalTime().ToString("yyyyMMdd_HHmmss");
+                string timestamp = _timeProvider.GetLocalNow().ToString("yyyyMMdd_HHmmss");
                 string taskLogDir = Path.Combine(
                     _pathService.LogsDirectory,
                     "Tasks",
@@ -87,12 +88,12 @@ public class TaskLoggerFactory(IPathService pathService, ILogger<TaskLoggerFacto
                     CaptureProperties = true
                 };
 
-                mainProvider = new DataStoreLoggerProvider(mainLogDataStore, mainConfig);
+                mainProvider = new DataStoreLoggerProvider(mainLogDataStore, _timeProvider, mainConfig);
                 protocolProvider = protocolLogDataStore != null
-                    ? new DataStoreLoggerProvider(protocolLogDataStore, protocolConfig)
+                    ? new DataStoreLoggerProvider(protocolLogDataStore, _timeProvider, protocolConfig)
                     : null;
                 processProvider = processLogDataStore != null
-                    ? new DataStoreLoggerProvider(processLogDataStore, mainConfig)
+                    ? new DataStoreLoggerProvider(processLogDataStore, _timeProvider, mainConfig)
                     : null;
 
                 // Create file logger providers

--- a/src/S7Tools/Services/PathService.cs
+++ b/src/S7Tools/Services/PathService.cs
@@ -401,7 +401,7 @@ namespace S7Tools.Services
         /// <returns>Full path to main log file</returns>
         public string GetMainLogPath(int rollingNumber = 0)
         {
-            string timestamp = DateTime.Now.ToString(FileNaming.TimestampFormat);
+            string timestamp = DateTime.UtcNow.ToLocalTime().ToString(FileNaming.TimestampFormat);
             string fileName = string.Format(ResourcePaths.MainLogFilePattern, timestamp, rollingNumber);
             return Path.Combine(MainLogsDirectory, fileName);
         }
@@ -418,7 +418,7 @@ namespace S7Tools.Services
                 throw new ArgumentException(UIStrings.Exception_FormatNullOrEmpty, nameof(format));
             }
 
-            string timestamp = DateTime.Now.ToString(FileNaming.TimestampFormat);
+            string timestamp = DateTime.UtcNow.ToLocalTime().ToString(FileNaming.TimestampFormat);
             string extension = format.ToLowerInvariant() switch
             {
                 "csv" => FileNaming.CsvExtension,

--- a/src/S7Tools/Services/SerialPortService.cs
+++ b/src/S7Tools/Services/SerialPortService.cs
@@ -199,7 +199,7 @@ public sealed partial class SerialPortService : ISerialPortService, IDisposable
                 IsAccessible = isAccessible,
                 IsInUse = await IsPortInUseAsync(portPath, cancellationToken).ConfigureAwait(false),
                 Description = GetPortDescription(portType),
-                LastUpdated = _timeProvider.GetUtcNow()
+                LastUpdated = _timeProvider.GetLocalNow()
             };
 
             // Get USB device info if it's a USB port
@@ -857,7 +857,7 @@ public sealed partial class SerialPortService : ISerialPortService, IDisposable
             config.DisableEchoControl = sttyOutput.Contains("-echoctl");
             config.DisableEchoKillErase = sttyOutput.Contains("-echoke");
 
-            config.ModifiedAt = _timeProvider.GetUtcNow();
+            config.ModifiedAt = _timeProvider.GetLocalNow();
         }
         catch (Exception ex)
         {

--- a/src/S7Tools/Services/SerialPortService.cs
+++ b/src/S7Tools/Services/SerialPortService.cs
@@ -24,6 +24,7 @@ public sealed partial class SerialPortService : ISerialPortService, IDisposable
 {
     private readonly ILogger<SerialPortService> _logger;
     private readonly IApplicationSettingsService _settingsService;
+    private readonly ITimeProvider _timeProvider;
     private readonly Timer _monitoringTimer;
     private readonly Dictionary<string, SerialPortInfo> _lastKnownPorts = [];
     private readonly SemaphoreSlim _semaphore = new(1, 1);
@@ -35,11 +36,16 @@ public sealed partial class SerialPortService : ISerialPortService, IDisposable
     /// </summary>
     /// <param name="logger">The logger instance for structured logging.</param>
     /// <param name="settingsService">The application settings service for runtime configuration.</param>
+    /// <param name="timeProvider">The time provider for abstracting time operations.</param>
     /// <exception cref="ArgumentNullException">Thrown when logger or settingsService is null.</exception>
-    public SerialPortService(ILogger<SerialPortService> logger, IApplicationSettingsService settingsService)
+    public SerialPortService(
+        ILogger<SerialPortService> logger,
+        IApplicationSettingsService settingsService,
+        ITimeProvider timeProvider)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _settingsService = settingsService ?? throw new ArgumentNullException(nameof(settingsService));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
 
         _logger.LogDebug("SerialPortService initialized with runtime settings from IApplicationSettingsService");
 
@@ -193,7 +199,7 @@ public sealed partial class SerialPortService : ISerialPortService, IDisposable
                 IsAccessible = isAccessible,
                 IsInUse = await IsPortInUseAsync(portPath, cancellationToken).ConfigureAwait(false),
                 Description = GetPortDescription(portType),
-                LastUpdated = DateTime.UtcNow
+                LastUpdated = _timeProvider.GetUtcNow()
             };
 
             // Get USB device info if it's a USB port
@@ -851,7 +857,7 @@ public sealed partial class SerialPortService : ISerialPortService, IDisposable
             config.DisableEchoControl = sttyOutput.Contains("-echoctl");
             config.DisableEchoKillErase = sttyOutput.Contains("-echoke");
 
-            config.ModifiedAt = DateTime.UtcNow;
+            config.ModifiedAt = _timeProvider.GetUtcNow();
         }
         catch (Exception ex)
         {

--- a/src/S7Tools/Services/SocatService.cs
+++ b/src/S7Tools/Services/SocatService.cs
@@ -1590,12 +1590,12 @@ public partial class SocatService : ISocatService, IDisposable
                         Configuration = new SocatConfiguration { TcpPort = port, TcpHost = host },
                         Profile = null,
                         CommandLine = cmd,
-                        StartTime = DateTime.UtcNow, // Fixed: Changed from DateTime.Now to DateTime.UtcNow
+                        StartTime = DateTime.UtcNow, // Reverted to UtcNow for internal consistency
                         IsRunning = true,
                         Status = SocatProcessStatus.Running,
                         ActiveConnections = 0,
                         TransferStats = new SocatTransferStats(),
-                        LastUpdated = DateTime.UtcNow // Fixed: Changed from DateTime.Now to DateTime.UtcNow
+                        LastUpdated = DateTime.UtcNow // Reverted to UtcNow for internal consistency
                     };
 
                     _runningProcesses[pid] = info;

--- a/src/S7Tools/Services/SocatService.cs
+++ b/src/S7Tools/Services/SocatService.cs
@@ -375,8 +375,6 @@ public partial class SocatService : ISocatService, IDisposable
 
         // NOW ACQUIRE SEMAPHORE - only protect shared state access
         _logger.LogDebug("Acquiring semaphore for socat start operation");
-        // NOW ACQUIRE SEMAPHORE - only protect shared state access
-        _logger.LogDebug("Acquiring semaphore for socat start operation");
         return await _semaphore.ExecuteAsync(async () =>
         {
             _logger.LogDebug("Checking concurrent instances: Current={Current}, Max={Max}",
@@ -637,30 +635,29 @@ public partial class SocatService : ISocatService, IDisposable
     /// <inheritdoc />
     public async Task<IEnumerable<SocatProcessInfo>> GetRunningProcessesAsync(CancellationToken cancellationToken = default)
     {
-        _logger.LogInformation("📋 GetRunningProcessesAsync ENTRY");
+        _logger.LogDebug("GetRunningProcessesAsync called");
 
         // Discover external socat processes first (outside lock to avoid long hold)
         await DiscoverExternalSocatProcessesAsync(cancellationToken).ConfigureAwait(false);
 
-        _logger.LogInformation("🔒 Waiting for semaphore...");
+        _logger.LogDebug("Waiting for semaphore...");
 
         return await _semaphore.ExecuteAsync(async () =>
         {
-            _logger.LogInformation("🔓 Semaphore acquired");
-
-            _logger.LogInformation("📊 Current _runningProcesses count before update: {Count}", _runningProcesses.Count);
+            _logger.LogDebug("Semaphore acquired");
+            _logger.LogDebug("Current running processes count before update: {Count}", _runningProcesses.Count);
 
             // Update process status before returning
-            _logger.LogInformation("🔄 Calling UpdateProcessStatusesAsync...");
+            _logger.LogDebug("Calling UpdateProcessStatusesAsync...");
             await UpdateProcessStatusesAsync().ConfigureAwait(false);
-            _logger.LogInformation("✅ UpdateProcessStatusesAsync completed");
+            _logger.LogDebug("UpdateProcessStatusesAsync completed");
 
-            _logger.LogInformation("📊 Final _runningProcesses count: {Count}", _runningProcesses.Count);
+            _logger.LogDebug("Final running processes count: {Count}", _runningProcesses.Count);
             var result = _runningProcesses.Values.ToList();
-            _logger.LogInformation("📊 Returning {Count} processes", result.Count);
+            _logger.LogDebug("Returning {Count} processes", result.Count);
 
-            _logger.LogInformation("🔓 Releasing semaphore (auto)...");
-            _logger.LogInformation("🏁 GetRunningProcessesAsync EXIT");
+            _logger.LogDebug("Releasing semaphore (auto)...");
+            _logger.LogDebug("GetRunningProcessesAsync complete");
             return (IEnumerable<SocatProcessInfo>)result;
         }, cancellationToken);
     }
@@ -1269,7 +1266,6 @@ public partial class SocatService : ISocatService, IDisposable
             }
 
             // Set up process exit handler before starting
-            // Set up process exit handler before starting
             process.Exited += (sender, args) => Task.Run(async () => await _semaphore.ExecuteAsync(async () =>
             {
                 if (_runningProcesses.TryGetValue(process.Id, out SocatProcessInfo? processInfo))
@@ -1282,12 +1278,15 @@ public partial class SocatService : ISocatService, IDisposable
                     ProcessStopped?.Invoke(this, new SocatProcessEventArgs(processInfo));
                 }
 
-                // Clean up references
+                // Clean up references - but DO NOT dispose process here
+                // Disposal is handled by StopSocatByIdAsync or the Exited handler cleanup
+                // Disposing here creates a race condition if StopSocatByIdAsync is running concurrently
                 _runningProcesses.Remove(process.Id);
                 _activeProcesses.Remove(process.Id);
 
-                // Dispose the process now that it's finished
-                process.Dispose();
+                // NOTE: Process will be disposed either by:
+                // 1. StopSocatByIdAsync when explicitly stopped
+                // 2. Garbage collection after all references are removed
                 await Task.CompletedTask;
             }));
 
@@ -1591,12 +1590,12 @@ public partial class SocatService : ISocatService, IDisposable
                         Configuration = new SocatConfiguration { TcpPort = port, TcpHost = host },
                         Profile = null,
                         CommandLine = cmd,
-                        StartTime = DateTime.Now,
+                        StartTime = DateTime.UtcNow, // Fixed: Changed from DateTime.Now to DateTime.UtcNow
                         IsRunning = true,
                         Status = SocatProcessStatus.Running,
                         ActiveConnections = 0,
                         TransferStats = new SocatTransferStats(),
-                        LastUpdated = DateTime.Now
+                        LastUpdated = DateTime.UtcNow // Fixed: Changed from DateTime.Now to DateTime.UtcNow
                     };
 
                     _runningProcesses[pid] = info;

--- a/src/S7Tools/Services/SocatService.cs
+++ b/src/S7Tools/Services/SocatService.cs
@@ -649,7 +649,7 @@ public partial class SocatService : ISocatService, IDisposable
 
             // Update process status before returning
             _logger.LogDebug("Calling UpdateProcessStatusesAsync...");
-            await UpdateProcessStatusesAsync().ConfigureAwait(false);
+            await UpdateProcessStatusesAsync(cancellationToken).ConfigureAwait(false);
             _logger.LogDebug("UpdateProcessStatusesAsync completed");
 
             _logger.LogDebug("Final running processes count: {Count}", _runningProcesses.Count);
@@ -788,7 +788,7 @@ public partial class SocatService : ISocatService, IDisposable
 
         return await _semaphore.ExecuteAsync(async () =>
         {
-            await UpdateProcessStatusesAsync().ConfigureAwait(false);
+            await UpdateProcessStatusesAsync(cancellationToken).ConfigureAwait(false);
             return _runningProcesses.Values.FirstOrDefault(p => p.TcpPort == tcpPort && p.IsRunning);
         }, cancellationToken);
     }
@@ -1506,7 +1506,7 @@ public partial class SocatService : ISocatService, IDisposable
     /// Updates the status of all running processes.
     /// </summary>
     /// <param name="cancellationToken">Token to cancel the operation.</param>
-    private async Task UpdateProcessStatusesAsync()
+    private async Task UpdateProcessStatusesAsync(CancellationToken cancellationToken = default)
     {
         var processIds = _runningProcesses.Keys.ToList();
 

--- a/src/S7Tools/Services/SocatService.cs
+++ b/src/S7Tools/Services/SocatService.cs
@@ -1324,7 +1324,7 @@ public partial class SocatService : ISocatService, IDisposable
                 Configuration = configuration.Clone(),
                 Profile = profile?.Clone(),
                 CommandLine = $"{fileName} {arguments}",
-                StartTime = _timeProvider.GetUtcNow(),
+                StartTime = _timeProvider.GetLocalNow(),
                 IsRunning = true,
                 Status = SocatProcessStatus.Running,
                 ActiveConnections = 0,
@@ -1334,10 +1334,10 @@ public partial class SocatService : ISocatService, IDisposable
                     BytesTcpToSerial = 0,
                     TotalConnections = 0,
                     ActiveConnections = 0,
-                    LastUpdated = _timeProvider.GetUtcNow(),
+                    LastUpdated = _timeProvider.GetLocalNow(),
                     Uptime = TimeSpan.Zero
                 },
-                LastUpdated = _timeProvider.GetUtcNow()
+                LastUpdated = _timeProvider.GetLocalNow()
             };
 
             // Store the actual Process object to keep it alive
@@ -1594,12 +1594,12 @@ public partial class SocatService : ISocatService, IDisposable
                         Configuration = new SocatConfiguration { TcpPort = port, TcpHost = host },
                         Profile = null,
                         CommandLine = cmd,
-                        StartTime = _timeProvider.GetUtcNow(), // Reverted to UtcNow for internal consistency
+                        StartTime = _timeProvider.GetLocalNow(), // Reverted from UtcNow for local consistency
                         IsRunning = true,
                         Status = SocatProcessStatus.Running,
                         ActiveConnections = 0,
                         TransferStats = new SocatTransferStats(),
-                        LastUpdated = _timeProvider.GetUtcNow() // Reverted to UtcNow for internal consistency
+                        LastUpdated = _timeProvider.GetLocalNow() // Reverted from UtcNow for local consistency
                     };
 
                     _runningProcesses[pid] = info;

--- a/src/S7Tools/Services/SocatService.cs
+++ b/src/S7Tools/Services/SocatService.cs
@@ -28,6 +28,7 @@ public partial class SocatService : ISocatService, IDisposable
     private readonly ILogger<SocatService> _logger;
     private readonly IApplicationSettingsService _settingsService;
     private readonly ISerialPortService _serialPortService;
+    private readonly ITimeProvider _timeProvider;
     private readonly Dictionary<int, SocatProcessInfo> _runningProcesses = [];
     private readonly Dictionary<int, Process> _activeProcesses = []; // Keep actual Process objects alive
     private readonly Dictionary<int, Timer> _processMonitors = [];
@@ -40,15 +41,18 @@ public partial class SocatService : ISocatService, IDisposable
     /// <param name="logger">The logger instance for structured logging.</param>
     /// <param name="settingsService">The application settings service for runtime configuration.</param>
     /// <param name="serialPortService">The serial port service for device validation and configuration.</param>
+    /// <param name="timeProvider">The time provider for abstracting time operations.</param>
     /// <exception cref="ArgumentNullException">Thrown when any parameter is null.</exception>
     public SocatService(
         ILogger<SocatService> logger,
         IApplicationSettingsService settingsService,
-        ISerialPortService serialPortService)
+        ISerialPortService serialPortService,
+        ITimeProvider timeProvider)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _settingsService = settingsService ?? throw new ArgumentNullException(nameof(settingsService));
         _serialPortService = serialPortService ?? throw new ArgumentNullException(nameof(serialPortService));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
 
         _logger.LogDebug("SocatService initialized with runtime settings from IApplicationSettingsService");
     }
@@ -1320,7 +1324,7 @@ public partial class SocatService : ISocatService, IDisposable
                 Configuration = configuration.Clone(),
                 Profile = profile?.Clone(),
                 CommandLine = $"{fileName} {arguments}",
-                StartTime = DateTime.UtcNow,
+                StartTime = _timeProvider.GetUtcNow(),
                 IsRunning = true,
                 Status = SocatProcessStatus.Running,
                 ActiveConnections = 0,
@@ -1330,10 +1334,10 @@ public partial class SocatService : ISocatService, IDisposable
                     BytesTcpToSerial = 0,
                     TotalConnections = 0,
                     ActiveConnections = 0,
-                    LastUpdated = DateTime.UtcNow,
+                    LastUpdated = _timeProvider.GetUtcNow(),
                     Uptime = TimeSpan.Zero
                 },
-                LastUpdated = DateTime.UtcNow
+                LastUpdated = _timeProvider.GetUtcNow()
             };
 
             // Store the actual Process object to keep it alive
@@ -1590,12 +1594,12 @@ public partial class SocatService : ISocatService, IDisposable
                         Configuration = new SocatConfiguration { TcpPort = port, TcpHost = host },
                         Profile = null,
                         CommandLine = cmd,
-                        StartTime = DateTime.UtcNow, // Reverted to UtcNow for internal consistency
+                        StartTime = _timeProvider.GetUtcNow(), // Reverted to UtcNow for internal consistency
                         IsRunning = true,
                         Status = SocatProcessStatus.Running,
                         ActiveConnections = 0,
                         TransferStats = new SocatTransferStats(),
-                        LastUpdated = DateTime.UtcNow // Reverted to UtcNow for internal consistency
+                        LastUpdated = _timeProvider.GetUtcNow() // Reverted to UtcNow for internal consistency
                     };
 
                     _runningProcesses[pid] = info;

--- a/src/S7Tools/Services/StructuredLogger.cs
+++ b/src/S7Tools/Services/StructuredLogger.cs
@@ -192,7 +192,7 @@ internal class OperationContext : IOperationContext
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         OperationName = operationName ?? throw new ArgumentNullException(nameof(operationName));
         Properties = new Dictionary<string, object>(properties);
-        StartTime = DateTime.Now;
+        StartTime = DateTime.UtcNow;
         _stopwatch = Stopwatch.StartNew();
 
         // Log operation start

--- a/src/S7Tools/Services/Tasking/EnhancedTaskScheduler.cs
+++ b/src/S7Tools/Services/Tasking/EnhancedTaskScheduler.cs
@@ -807,7 +807,6 @@ public class EnhancedTaskScheduler : ITaskScheduler, IDisposable
                 // Clean up tracking when task completes
                 _ = executionTask.ContinueWith(t => _activeExecutions.TryRemove(taskId, out _), TaskScheduler.Default);
             }
-            await Task.CompletedTask;
         });
     }
 
@@ -916,9 +915,10 @@ public class EnhancedTaskScheduler : ITaskScheduler, IDisposable
                 lock (_executionTimes)
                 {
                     _executionTimes.Enqueue(task.ExecutionTime.Value);
+                    // M-3: Enforce max count to prevent unbounded growth
                     while (_executionTimes.Count > MaxExecutionTimesCount)
                     {
-                        _executionTimes.Dequeue(); // O(1) instead of List.RemoveAt(0) which is O(n)
+                        _executionTimes.Dequeue(); // O(1) operation
                     }
                 }
             }

--- a/src/S7Tools/Services/Tasking/EnhancedTaskScheduler.cs
+++ b/src/S7Tools/Services/Tasking/EnhancedTaskScheduler.cs
@@ -195,21 +195,18 @@ public class EnhancedTaskScheduler : ITaskScheduler, IDisposable
     /// </summary>
     private bool TryEnqueueInternal(Guid taskId, TaskExecution task, string? stateMessage = null)
     {
-        lock (_taskQueue)
+        if (_taskQueue.Count >= MaxQueueSize)
         {
-            if (_taskQueue.Count >= MaxQueueSize)
-            {
-                _logger.LogError("Task queue is full ({Count}/{Max}). Cannot enqueue task {TaskId}",
-                    _taskQueue.Count, MaxQueueSize, taskId);
-                task.UpdateState(TaskState.Failed, $"Task queue is full ({MaxQueueSize})");
-                TaskStateChanged?.Invoke(task);
-                return false;
-            }
-
-            task.UpdateState(TaskState.Queued, stateMessage ?? "Task queued for execution");
-            _taskQueue.Enqueue(taskId);
-            return true;
+            _logger.LogError("Task queue is full ({Count}/{Max}). Cannot enqueue task {TaskId}",
+                _taskQueue.Count, MaxQueueSize, taskId);
+            task.UpdateState(TaskState.Failed, $"Task queue is full ({MaxQueueSize})");
+            TaskStateChanged?.Invoke(task);
+            return false;
         }
+
+        task.UpdateState(TaskState.Queued, stateMessage ?? "Task queued for execution");
+        _taskQueue.Enqueue(taskId);
+        return true;
     }
 
     /// <inheritdoc/>

--- a/src/S7Tools/Services/Tasking/EnhancedTaskScheduler.cs
+++ b/src/S7Tools/Services/Tasking/EnhancedTaskScheduler.cs
@@ -177,19 +177,23 @@ public class EnhancedTaskScheduler : ITaskScheduler, IDisposable
 
         // Check queue size limit to prevent unbounded growth
         const int MaxQueueSize = 1000; // Maximum number of queued tasks
-        int currentQueueCount = _taskQueue.Count;
 
-        if (currentQueueCount >= MaxQueueSize)
+        lock (_taskQueue)
         {
-            _logger.LogError("Task queue is full ({Count}/{Max}). Cannot enqueue task {TaskId}",
-                currentQueueCount, MaxQueueSize, taskId);
-            task.UpdateState(TaskState.Failed, $"Task queue is full ({currentQueueCount}/{MaxQueueSize})");
-            TaskStateChanged?.Invoke(task);
-            return Task.FromResult(false);
-        }
+            int currentQueueCount = _taskQueue.Count;
 
-        task.UpdateState(TaskState.Queued, "Task queued for execution");
-        _taskQueue.Enqueue(taskId);
+            if (currentQueueCount >= MaxQueueSize)
+            {
+                _logger.LogError("Task queue is full ({Count}/{Max}). Cannot enqueue task {TaskId}",
+                    currentQueueCount, MaxQueueSize, taskId);
+                task.UpdateState(TaskState.Failed, $"Task queue is full ({currentQueueCount}/{MaxQueueSize})");
+                TaskStateChanged?.Invoke(task);
+                return Task.FromResult(false);
+            }
+
+            task.UpdateState(TaskState.Queued, "Task queued for execution");
+            _taskQueue.Enqueue(taskId);
+        }
 
         TaskStateChanged?.Invoke(task);
 

--- a/src/S7Tools/Services/Tasking/EnhancedTaskScheduler.cs
+++ b/src/S7Tools/Services/Tasking/EnhancedTaskScheduler.cs
@@ -175,12 +175,26 @@ public class EnhancedTaskScheduler : ITaskScheduler, IDisposable
             return Task.FromResult(false);
         }
 
+        // Check queue size limit to prevent unbounded growth
+        const int MaxQueueSize = 1000; // Maximum number of queued tasks
+        int currentQueueCount = _tasks.Values.Count(t => t.State == TaskState.Queued);
+
+        if (currentQueueCount >= MaxQueueSize)
+        {
+            _logger.LogError("Task queue is full ({Count}/{Max}). Cannot enqueue task {TaskId}",
+                currentQueueCount, MaxQueueSize, taskId);
+            task.UpdateState(TaskState.Failed, $"Task queue is full ({currentQueueCount}/{MaxQueueSize})");
+            TaskStateChanged?.Invoke(task);
+            return Task.FromResult(false);
+        }
+
         task.UpdateState(TaskState.Queued, "Task queued for execution");
         _taskQueue.Enqueue(taskId);
 
         TaskStateChanged?.Invoke(task);
 
-        _logger.LogInformation("Enqueued task {TaskId} ({JobName})", taskId, task.JobName);
+        _logger.LogInformation("Enqueued task {TaskId} ({JobName}) - Queue size: {QueueSize}/{MaxSize}",
+            taskId, task.JobName, currentQueueCount + 1, MaxQueueSize);
         return Task.FromResult(true);
     }
 

--- a/src/S7Tools/Services/Tasking/EnhancedTaskScheduler.cs
+++ b/src/S7Tools/Services/Tasking/EnhancedTaskScheduler.cs
@@ -827,13 +827,22 @@ public class EnhancedTaskScheduler : ITaskScheduler, IDisposable
             // Start the tasks with tracking to prevent race conditions
             foreach (Guid taskId in tasksToStart)
             {
-                Task executionTask = ExecuteTaskAsync(taskId);
+                Task executionTask = ExecuteAndTrackTaskAsync(taskId);
                 _activeExecutions.TryAdd(taskId, executionTask);
-
-                // Clean up tracking when task completes
-                _ = executionTask.ContinueWith(t => _activeExecutions.TryRemove(taskId, out _), TaskScheduler.Default);
             }
         });
+    }
+
+    private async Task ExecuteAndTrackTaskAsync(Guid taskId)
+    {
+        try
+        {
+            await ExecuteTaskAsync(taskId).ConfigureAwait(false);
+        }
+        finally
+        {
+            _activeExecutions.TryRemove(taskId, out _);
+        }
     }
 
     /// <summary>

--- a/src/S7Tools/Services/Tasking/EnhancedTaskScheduler.cs
+++ b/src/S7Tools/Services/Tasking/EnhancedTaskScheduler.cs
@@ -177,7 +177,7 @@ public class EnhancedTaskScheduler : ITaskScheduler, IDisposable
 
         // Check queue size limit to prevent unbounded growth
         const int MaxQueueSize = 1000; // Maximum number of queued tasks
-        int currentQueueCount = _tasks.Values.Count(t => t.State == TaskState.Queued);
+        int currentQueueCount = _taskQueue.Count;
 
         if (currentQueueCount >= MaxQueueSize)
         {

--- a/src/S7Tools/Services/Tasking/EnhancedTaskScheduler.cs
+++ b/src/S7Tools/Services/Tasking/EnhancedTaskScheduler.cs
@@ -153,7 +153,7 @@ public class EnhancedTaskScheduler : ITaskScheduler, IDisposable
             State = TaskState.Created,
             Priority = priority,
             LockedResources = executionJob.Resources,
-            CreatedAt = _timeProvider.GetUtcNow()
+            CreatedAt = _timeProvider.GetLocalNow()
         };
         taskExecution.Initialize(_timeProvider);
 

--- a/src/S7Tools/Services/Tasking/EnhancedTaskScheduler.cs
+++ b/src/S7Tools/Services/Tasking/EnhancedTaskScheduler.cs
@@ -26,6 +26,7 @@ public class EnhancedTaskScheduler : ITaskScheduler, IDisposable
     private readonly IJobManager _jobManager;
     private readonly IPathService _pathService;
     private readonly ITaskLoggerFactory _taskLoggerFactory;
+    private readonly ITimeProvider _timeProvider;
     private readonly string _tasksFilePath;
 
     private readonly ConcurrentDictionary<Guid, TaskExecution> _tasks = new();
@@ -42,7 +43,7 @@ public class EnhancedTaskScheduler : ITaskScheduler, IDisposable
     private bool _isRunning;
     private bool _disposed;
     private int _maxConcurrentTasks = Environment.ProcessorCount;
-    private readonly DateTime _startTime = DateTime.UtcNow;
+    private readonly DateTime _startTime;
 
     // Statistics
     private long _totalTasksProcessed;
@@ -76,13 +77,15 @@ public class EnhancedTaskScheduler : ITaskScheduler, IDisposable
     /// <param name="jobManager">Job manager for accessing job configurations.</param>
     /// <param name="pathService">Path service for resolving application paths.</param>
     /// <param name="taskLoggerFactory">Task logger factory for creating task-specific loggers.</param>
+    /// <param name="timeProvider">Time provider for consistent task scheduling.</param>
     public EnhancedTaskScheduler(
         ILogger<EnhancedTaskScheduler> logger,
         IResourceCoordinator resourceCoordinator,
         IBootloaderService bootloaderService,
         IJobManager jobManager,
         IPathService pathService,
-        ITaskLoggerFactory taskLoggerFactory)
+        ITaskLoggerFactory taskLoggerFactory,
+        ITimeProvider timeProvider)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _resourceCoordinator = resourceCoordinator ?? throw new ArgumentNullException(nameof(resourceCoordinator));
@@ -90,6 +93,9 @@ public class EnhancedTaskScheduler : ITaskScheduler, IDisposable
         _jobManager = jobManager ?? throw new ArgumentNullException(nameof(jobManager));
         _pathService = pathService ?? throw new ArgumentNullException(nameof(pathService));
         _taskLoggerFactory = taskLoggerFactory ?? throw new ArgumentNullException(nameof(taskLoggerFactory));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+
+        _startTime = _timeProvider.GetUtcNow();
 
         // Set up tasks file path using PathService
         _tasksFilePath = _pathService.TasksPath;
@@ -147,8 +153,9 @@ public class EnhancedTaskScheduler : ITaskScheduler, IDisposable
             State = TaskState.Created,
             Priority = priority,
             LockedResources = executionJob.Resources,
-            CreatedAt = DateTime.UtcNow
+            CreatedAt = _timeProvider.GetUtcNow()
         };
+        taskExecution.Initialize(_timeProvider);
 
         _tasks[taskExecution.TaskId] = taskExecution;
 
@@ -243,7 +250,7 @@ public class EnhancedTaskScheduler : ITaskScheduler, IDisposable
             taskId, task.JobName, localTime);
 
         // If time already passed or is now, promote to queue immediately
-        if (utcTime <= DateTime.UtcNow)
+        if (utcTime <= _timeProvider.GetUtcNow())
         {
             _scheduledTasks.TryRemove(taskId, out _);
             if (!TryEnqueueInternal(taskId, task, "Promoted to queue from schedule"))
@@ -641,12 +648,12 @@ public class EnhancedTaskScheduler : ITaskScheduler, IDisposable
 
             // Add 30-second timeout to prevent infinite wait
             const int maxWaitSeconds = 30;
-            DateTime startTime = DateTime.UtcNow;
+            DateTime startTime = _timeProvider.GetUtcNow();
 
             while (runningTasks.Count > 0)
             {
                 // Check if timeout elapsed
-                if ((DateTime.UtcNow - startTime).TotalSeconds >= maxWaitSeconds)
+                if ((_timeProvider.GetUtcNow() - startTime).TotalSeconds >= maxWaitSeconds)
                 {
                     _logger.LogWarning("Graceful shutdown timeout reached after {Seconds} seconds with {Count} tasks still running",
                         maxWaitSeconds, runningTasks.Count);
@@ -687,7 +694,7 @@ public class EnhancedTaskScheduler : ITaskScheduler, IDisposable
     /// <inheritdoc/>
     public async Task<int> CleanupOldTasksAsync(TimeSpan maxAge, CancellationToken cancellationToken = default)
     {
-        DateTime cutoffTime = DateTime.UtcNow - maxAge;
+        DateTime cutoffTime = _timeProvider.GetUtcNow() - maxAge;
         var oldTasks = _tasks.Values
             .Where(t => t.IsTerminal && t.CompletedAt < cutoffTime)
             .ToList();
@@ -722,7 +729,7 @@ public class EnhancedTaskScheduler : ITaskScheduler, IDisposable
             CancelledTasks = _cancelledTasks,
             AverageExecutionTime = averageExecutionTime,
             TasksByState = tasksByState,
-            Uptime = DateTime.UtcNow - _startTime
+            Uptime = _timeProvider.GetUtcNow() - _startTime
         };
     }
 
@@ -764,7 +771,7 @@ public class EnhancedTaskScheduler : ITaskScheduler, IDisposable
             // Promote due scheduled tasks
             if (!_scheduledTasks.IsEmpty)
             {
-                DateTime nowUtc = DateTime.UtcNow;
+                DateTime nowUtc = _timeProvider.GetUtcNow();
                 List<Guid> dueTaskIds = [.. _scheduledTasks.Where(kvp => kvp.Value <= nowUtc).Select(kvp => kvp.Key)];
                 foreach (Guid dueId in dueTaskIds)
                 {

--- a/src/S7Tools/Services/Tasking/EnhancedTaskScheduler.cs
+++ b/src/S7Tools/Services/Tasking/EnhancedTaskScheduler.cs
@@ -30,6 +30,7 @@ public class EnhancedTaskScheduler : ITaskScheduler, IDisposable
 
     private readonly ConcurrentDictionary<Guid, TaskExecution> _tasks = new();
     private readonly ConcurrentQueue<Guid> _taskQueue = new();
+    private const int MaxQueueSize = 1000;
     private readonly ConcurrentDictionary<Guid, DateTime> _scheduledTasks = new();
     private readonly ConcurrentDictionary<Guid, Task> _activeExecutions = new(); // Track active execution tasks
     private readonly SemaphoreSlim _schedulerSemaphore = new(1, 1);
@@ -175,31 +176,40 @@ public class EnhancedTaskScheduler : ITaskScheduler, IDisposable
             return Task.FromResult(false);
         }
 
-        // Check queue size limit to prevent unbounded growth
-        const int MaxQueueSize = 1000; // Maximum number of queued tasks
-
-        lock (_taskQueue)
+        if (!TryEnqueueInternal(taskId, task))
         {
-            int currentQueueCount = _taskQueue.Count;
-
-            if (currentQueueCount >= MaxQueueSize)
-            {
-                _logger.LogError("Task queue is full ({Count}/{Max}). Cannot enqueue task {TaskId}",
-                    currentQueueCount, MaxQueueSize, taskId);
-                task.UpdateState(TaskState.Failed, $"Task queue is full ({currentQueueCount}/{MaxQueueSize})");
-                TaskStateChanged?.Invoke(task);
-                return Task.FromResult(false);
-            }
-
-            task.UpdateState(TaskState.Queued, "Task queued for execution");
-            _taskQueue.Enqueue(taskId);
+            return Task.FromResult(false);
         }
 
         TaskStateChanged?.Invoke(task);
 
         _logger.LogInformation("Enqueued task {TaskId} ({JobName}) - Queue size: {QueueSize}/{MaxSize}",
-            taskId, task.JobName, currentQueueCount + 1, MaxQueueSize);
+            taskId, task.JobName, _taskQueue.Count, MaxQueueSize);
+
         return Task.FromResult(true);
+    }
+
+    /// <summary>
+    /// Attempts to enqueue a task while respecting the maximum queue size.
+    /// Updates task state to Failed if the queue is full.
+    /// </summary>
+    private bool TryEnqueueInternal(Guid taskId, TaskExecution task, string? stateMessage = null)
+    {
+        lock (_taskQueue)
+        {
+            if (_taskQueue.Count >= MaxQueueSize)
+            {
+                _logger.LogError("Task queue is full ({Count}/{Max}). Cannot enqueue task {TaskId}",
+                    _taskQueue.Count, MaxQueueSize, taskId);
+                task.UpdateState(TaskState.Failed, $"Task queue is full ({MaxQueueSize})");
+                TaskStateChanged?.Invoke(task);
+                return false;
+            }
+
+            task.UpdateState(TaskState.Queued, stateMessage ?? "Task queued for execution");
+            _taskQueue.Enqueue(taskId);
+            return true;
+        }
     }
 
     /// <inheritdoc/>
@@ -217,17 +227,18 @@ public class EnhancedTaskScheduler : ITaskScheduler, IDisposable
             return Task.FromResult(false);
         }
 
-        // Normalize to Local timezone per requirement
-        DateTime localTime = scheduledTime.Kind switch
+        // Normalize to UTC for internal storage and comparison
+        DateTime utcTime = scheduledTime.Kind switch
         {
-            DateTimeKind.Unspecified => DateTime.SpecifyKind(scheduledTime, DateTimeKind.Local),
-            DateTimeKind.Utc => scheduledTime.ToLocalTime(),
+            DateTimeKind.Unspecified => DateTime.SpecifyKind(scheduledTime, DateTimeKind.Local).ToUniversalTime(),
+            DateTimeKind.Local => scheduledTime.ToUniversalTime(),
             _ => scheduledTime
         };
+        DateTime localTime = utcTime.ToLocalTime();
 
         task.UpdateState(TaskState.Scheduled, $"Scheduled for {localTime}");
-        task.ProgressData["ScheduledTime"] = localTime;
-        _scheduledTasks[taskId] = localTime;
+        task.ProgressData["ScheduledTime"] = utcTime;
+        _scheduledTasks[taskId] = utcTime;
 
         TaskStateChanged?.Invoke(task);
 
@@ -235,12 +246,17 @@ public class EnhancedTaskScheduler : ITaskScheduler, IDisposable
             taskId, task.JobName, localTime);
 
         // If time already passed or is now, promote to queue immediately
-        if (localTime <= DateTime.UtcNow)
+        if (utcTime <= DateTime.UtcNow)
         {
             _scheduledTasks.TryRemove(taskId, out _);
-            task.UpdateState(TaskState.Queued, "Promoted to queue from schedule");
-            TaskStateChanged?.Invoke(task);
-            _taskQueue.Enqueue(taskId);
+            if (!TryEnqueueInternal(taskId, task, "Promoted to queue from schedule"))
+            {
+                _logger.LogWarning("Failed to promote scheduled task {TaskId} to queue because it is full", taskId);
+            }
+            else
+            {
+                TaskStateChanged?.Invoke(task);
+            }
         }
 
         return Task.FromResult(true);
@@ -487,7 +503,7 @@ public class EnhancedTaskScheduler : ITaskScheduler, IDisposable
         Job executionJob = jobProfile.ToExecutionJob();
         foreach (ResourceKey resource in executionJob.Resources)
         {
-            if (!_resourceCoordinator.TryAcquire([resource]))
+            if (!_resourceCoordinator.AreAvailable([resource]))
             {
                 // Resource is locked - find which task is using it
                 TaskExecution? lockingTask = _tasks.Values.FirstOrDefault(t =>
@@ -499,7 +515,7 @@ public class EnhancedTaskScheduler : ITaskScheduler, IDisposable
                     switch (resource.Kind.ToLowerInvariant())
                     {
                         case "serial":
-                            reasons.Add($"Serial port '{resource.Id}' is in use by task '{lockingTask.JobName}' (started {lockingTask.StartedAt:HH:mm:ss})");
+                            reasons.Add($"Serial port '{resource.Id}' is in use by task '{lockingTask.JobName}' (started {lockingTask.StartedAt?.ToLocalTime():HH:mm:ss})");
                             break;
                         case "tcp":
                             reasons.Add($"TCP port {resource.Id} is in use by task '{lockingTask.JobName}' (socat server running)");
@@ -757,9 +773,14 @@ public class EnhancedTaskScheduler : ITaskScheduler, IDisposable
                 {
                     if (_tasks.TryGetValue(dueId, out TaskExecution? scheduledTask) && scheduledTask.State == TaskState.Scheduled)
                     {
-                        scheduledTask.UpdateState(TaskState.Queued, "Promoted to queue from schedule");
-                        TaskStateChanged?.Invoke(scheduledTask);
-                        _taskQueue.Enqueue(dueId);
+                        if (!TryEnqueueInternal(dueId, scheduledTask, "Promoted to queue from schedule"))
+                        {
+                            _logger.LogWarning("Failed to promote due scheduled task {TaskId} to queue because it is full", dueId);
+                        }
+                        else
+                        {
+                            TaskStateChanged?.Invoke(scheduledTask);
+                        }
                     }
                     _scheduledTasks.TryRemove(dueId, out _);
                 }
@@ -795,7 +816,7 @@ public class EnhancedTaskScheduler : ITaskScheduler, IDisposable
                         task.UpdateProgress(task.ProgressPercentage, $"Waiting: {reasonsText}");
                         TaskProgressUpdated?.Invoke(task.TaskId, task.ProgressPercentage, task.CurrentOperation ?? string.Empty);
 
-                        // Re-queue for later
+                        // Re-queue for later (bypass check as we just dequeued it)
                         _taskQueue.Enqueue(taskId);
                         break; // Stop trying if resources aren't available
                     }
@@ -846,7 +867,7 @@ public class EnhancedTaskScheduler : ITaskScheduler, IDisposable
             // Log task start
             taskLogger.MainLogger?.LogInformation(
                 "Task execution started: {JobName} (ID: {TaskId}) at {StartTime}",
-                task.JobName, taskId, DateTime.UtcNow);
+                task.JobName, taskId, DateTime.UtcNow.ToLocalTime());
 
             // Get the job profile
             JobProfile jobProfile = await _jobManager.GetByIdAsync(task.JobProfileId).ConfigureAwait(false)
@@ -1079,7 +1100,10 @@ public class EnhancedTaskScheduler : ITaskScheduler, IDisposable
                         // Restore queued and scheduled tasks to their queues
                         if (task.State == TaskState.Queued)
                         {
-                            _taskQueue.Enqueue(task.TaskId);
+                            if (!TryEnqueueInternal(task.TaskId, task, "Restored queued task"))
+                            {
+                                _logger.LogWarning("Failed to restore queued task {TaskId} because queue is full", task.TaskId);
+                            }
                         }
                         else if (task.State == TaskState.Scheduled && task.ProgressData.TryGetValue("ScheduledTime", out object? scheduledObj))
                         {
@@ -1088,15 +1112,19 @@ public class EnhancedTaskScheduler : ITaskScheduler, IDisposable
                                 string? dateString = jsonElement.GetString();
                                 if (!string.IsNullOrEmpty(dateString) && DateTime.TryParse(dateString, out DateTime scheduledTime))
                                 {
-                                    _scheduledTasks[task.TaskId] = scheduledTime;
+                                    _scheduledTasks[task.TaskId] = scheduledTime.Kind == DateTimeKind.Unspecified
+                                        ? DateTime.SpecifyKind(scheduledTime, DateTimeKind.Utc)
+                                        : scheduledTime.ToUniversalTime();
                                 }
                             }
                         }
                         // Reset running tasks to queued (they were interrupted by app close)
                         else if (task.State == TaskState.Running)
                         {
-                            task.UpdateState(TaskState.Queued, "Restored from interrupted session");
-                            _taskQueue.Enqueue(task.TaskId);
+                            if (!TryEnqueueInternal(task.TaskId, task, "Restored from interrupted session"))
+                            {
+                                _logger.LogWarning("Failed to restore interrupted running task {TaskId} because queue is full", task.TaskId);
+                            }
                         }
                     }
 

--- a/src/S7Tools/Services/Tasking/EnhancedTaskScheduler.cs
+++ b/src/S7Tools/Services/Tasking/EnhancedTaskScheduler.cs
@@ -643,30 +643,27 @@ public class EnhancedTaskScheduler : ITaskScheduler, IDisposable
         if (graceful)
         {
             // Wait for running tasks to complete with a timeout
-            IReadOnlyCollection<TaskExecution> runningTasks = await GetRunningTasksAsync(cancellationToken).ConfigureAwait(false);
-            _logger.LogInformation("Waiting for {Count} running tasks to complete (max 30 seconds)", runningTasks.Count);
+            var activeExecutionTasks = _activeExecutions.Values.ToList();
+            _logger.LogInformation("Waiting for {Count} running tasks to complete (max 30 seconds)", activeExecutionTasks.Count);
 
-            // Add 30-second timeout to prevent infinite wait
-            const int maxWaitSeconds = 30;
-            DateTime startTime = _timeProvider.GetUtcNow();
-
-            while (runningTasks.Count > 0)
+            if (activeExecutionTasks.Count > 0)
             {
-                // Check if timeout elapsed
-                if ((_timeProvider.GetUtcNow() - startTime).TotalSeconds >= maxWaitSeconds)
+                var allTasks = Task.WhenAll(activeExecutionTasks);
+                var timeoutTask = Task.Delay(TimeSpan.FromSeconds(30), cancellationToken);
+
+                var completedTask = await Task.WhenAny(allTasks, timeoutTask).ConfigureAwait(false);
+
+                if (completedTask == timeoutTask)
                 {
-                    _logger.LogWarning("Graceful shutdown timeout reached after {Seconds} seconds with {Count} tasks still running",
-                        maxWaitSeconds, runningTasks.Count);
-                    break;
+                    _logger.LogWarning("Graceful shutdown timeout reached after 30 seconds with {Count} tasks still running",
+                        _activeExecutions.Count);
                 }
-
-                await Task.Delay(1000, cancellationToken).ConfigureAwait(false);
-                runningTasks = await GetRunningTasksAsync(cancellationToken).ConfigureAwait(false);
-            }
-
-            if (runningTasks.Count == 0)
-            {
-                _logger.LogInformation("All running tasks completed before shutdown");
+                else
+                {
+                    // Await the WhenAll task to propagate any exceptions from the tasks.
+                    await allTasks.ConfigureAwait(false);
+                    _logger.LogInformation("All running tasks completed before shutdown");
+                }
             }
         }
 

--- a/src/S7Tools/Services/Tasking/EnhancedTaskScheduler.cs
+++ b/src/S7Tools/Services/Tasking/EnhancedTaskScheduler.cs
@@ -604,14 +604,31 @@ public class EnhancedTaskScheduler : ITaskScheduler, IDisposable
 
         if (graceful)
         {
-            // Wait for running tasks to complete
+            // Wait for running tasks to complete with a timeout
             IReadOnlyCollection<TaskExecution> runningTasks = await GetRunningTasksAsync(cancellationToken).ConfigureAwait(false);
-            _logger.LogInformation("Waiting for {Count} running tasks to complete", runningTasks.Count);
+            _logger.LogInformation("Waiting for {Count} running tasks to complete (max 30 seconds)", runningTasks.Count);
+
+            // Add 30-second timeout to prevent infinite wait
+            const int maxWaitSeconds = 30;
+            DateTime startTime = DateTime.UtcNow;
 
             while (runningTasks.Count > 0)
             {
+                // Check if timeout elapsed
+                if ((DateTime.UtcNow - startTime).TotalSeconds >= maxWaitSeconds)
+                {
+                    _logger.LogWarning("Graceful shutdown timeout reached after {Seconds} seconds with {Count} tasks still running",
+                        maxWaitSeconds, runningTasks.Count);
+                    break;
+                }
+
                 await Task.Delay(1000, cancellationToken).ConfigureAwait(false);
                 runningTasks = await GetRunningTasksAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            if (runningTasks.Count == 0)
+            {
+                _logger.LogInformation("All running tasks completed before shutdown");
             }
         }
 

--- a/src/S7Tools/Services/Tasking/JobScheduler.cs
+++ b/src/S7Tools/Services/Tasking/JobScheduler.cs
@@ -345,7 +345,7 @@ public sealed class JobScheduler(
 
             // STEP 2: Save dump data to output path
             string outputPath = job.ProfileSet.OutputPath;
-            string filename = $"dump_{job.Id}_{DateTime.UtcNow:yyyyMMdd_HHmmss}.bin";
+            string filename = $"dump_{job.Id}_{DateTime.UtcNow.ToLocalTime():yyyyMMdd_HHmmss}.bin";
             string fullPath = Path.Combine(outputPath, filename);
 
             Directory.CreateDirectory(outputPath); // Ensure directory exists
@@ -371,7 +371,7 @@ public sealed class JobScheduler(
                 JobState.Completed,
                 null));
 
-            _logger.LogInformation("✅ Job {JobId} completed successfully", job.Id);
+            _logger.LogInformation("Job {JobId} completed successfully", job.Id);
         }
         catch (OperationCanceledException)
         {
@@ -397,7 +397,7 @@ public sealed class JobScheduler(
         catch (Exception ex)
         {
             // Unexpected error - transition to Failed state
-            _logger.LogError(ex, "❌ Job {JobId} failed: {ErrorMessage}", job.Id, ex.Message);
+            _logger.LogError(ex, "Job {JobId} failed: {ErrorMessage}", job.Id, ex.Message);
 
             Job failedJob = job with
             {

--- a/src/S7Tools/Services/Tasking/JobScheduler.cs
+++ b/src/S7Tools/Services/Tasking/JobScheduler.cs
@@ -13,12 +13,14 @@ namespace S7Tools.Services.Tasking;
 public sealed class JobScheduler(
     ILogger<JobScheduler> logger,
     IResourceCoordinator resources,
-    IBootloaderService bootloader)
+    IBootloaderService bootloader,
+    ITimeProvider timeProvider)
     : IJobScheduler, IDisposable
 {
     private readonly ILogger<JobScheduler> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     private readonly IResourceCoordinator _resources = resources ?? throw new ArgumentNullException(nameof(resources));
     private readonly IBootloaderService _bootloader = bootloader ?? throw new ArgumentNullException(nameof(bootloader));
+    private readonly ITimeProvider _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
     private readonly ConcurrentDictionary<int, Job> _jobs = [];
     private readonly ConcurrentDictionary<int, Task> _runningJobs = [];
     private readonly SemaphoreSlim _schedulerLock = new(1, 1);
@@ -48,8 +50,8 @@ public sealed class JobScheduler(
         Job queuedJob = job with
         {
             State = JobState.Queued,
-            QueuedAt = DateTime.UtcNow,
-            ModifiedAt = DateTime.UtcNow
+            QueuedAt = _timeProvider.GetUtcNow(),
+            ModifiedAt = _timeProvider.GetUtcNow()
         };
 
         _jobs[job.Id] = queuedJob;
@@ -80,8 +82,8 @@ public sealed class JobScheduler(
         Job canceledJob = job with
         {
             State = JobState.Canceled,
-            CompletedAt = DateTime.UtcNow,
-            ModifiedAt = DateTime.UtcNow
+            CompletedAt = _timeProvider.GetUtcNow(),
+            ModifiedAt = _timeProvider.GetUtcNow()
         };
 
         _jobs[jobId] = canceledJob;
@@ -256,8 +258,8 @@ public sealed class JobScheduler(
                     Job runningJob = job with
                     {
                         State = JobState.Running,
-                        StartedAt = DateTime.UtcNow,
-                        ModifiedAt = DateTime.UtcNow
+                        StartedAt = _timeProvider.GetUtcNow(),
+                        ModifiedAt = _timeProvider.GetUtcNow()
                     };
                     _jobs[job.Id] = runningJob;
 
@@ -320,7 +322,7 @@ public sealed class JobScheduler(
                 {
                     Progress = percentage,
                     CurrentOperation = operation,
-                    ModifiedAt = DateTime.UtcNow
+                    ModifiedAt = _timeProvider.GetUtcNow()
                 };
                 _jobs[job.Id] = progressJob;
 
@@ -345,7 +347,7 @@ public sealed class JobScheduler(
 
             // STEP 2: Save dump data to output path
             string outputPath = job.ProfileSet.OutputPath;
-            string filename = $"dump_{job.Id}_{DateTime.UtcNow.ToLocalTime():yyyyMMdd_HHmmss}.bin";
+            string filename = $"dump_{job.Id}_{_timeProvider.GetLocalNow():yyyyMMdd_HHmmss}.bin";
             string fullPath = Path.Combine(outputPath, filename);
 
             Directory.CreateDirectory(outputPath); // Ensure directory exists
@@ -360,8 +362,8 @@ public sealed class JobScheduler(
                 State = JobState.Completed,
                 Progress = 100.0,
                 CurrentOperation = "Complete",
-                CompletedAt = DateTime.UtcNow,
-                ModifiedAt = DateTime.UtcNow
+                CompletedAt = _timeProvider.GetUtcNow(),
+                ModifiedAt = _timeProvider.GetUtcNow()
             };
             _jobs[job.Id] = completedJob;
 
@@ -380,8 +382,8 @@ public sealed class JobScheduler(
             {
                 State = JobState.Canceled,
                 ErrorMessage = "Operation canceled by user",
-                CompletedAt = DateTime.UtcNow,
-                ModifiedAt = DateTime.UtcNow
+                CompletedAt = _timeProvider.GetUtcNow(),
+                ModifiedAt = _timeProvider.GetUtcNow()
             };
             _jobs[job.Id] = canceledJob;
 
@@ -403,8 +405,8 @@ public sealed class JobScheduler(
             {
                 State = JobState.Failed,
                 ErrorMessage = ex.Message,
-                CompletedAt = DateTime.UtcNow,
-                ModifiedAt = DateTime.UtcNow
+                CompletedAt = _timeProvider.GetUtcNow(),
+                ModifiedAt = _timeProvider.GetUtcNow()
             };
             _jobs[job.Id] = failedJob;
 

--- a/src/S7Tools/Services/Tasking/JobScheduler.cs
+++ b/src/S7Tools/Services/Tasking/JobScheduler.cs
@@ -50,8 +50,8 @@ public sealed class JobScheduler(
         Job queuedJob = job with
         {
             State = JobState.Queued,
-            QueuedAt = _timeProvider.GetUtcNow(),
-            ModifiedAt = _timeProvider.GetUtcNow()
+            QueuedAt = _timeProvider.GetLocalNow(),
+            ModifiedAt = _timeProvider.GetLocalNow()
         };
 
         _jobs[job.Id] = queuedJob;
@@ -82,8 +82,8 @@ public sealed class JobScheduler(
         Job canceledJob = job with
         {
             State = JobState.Canceled,
-            CompletedAt = _timeProvider.GetUtcNow(),
-            ModifiedAt = _timeProvider.GetUtcNow()
+            CompletedAt = _timeProvider.GetLocalNow(),
+            ModifiedAt = _timeProvider.GetLocalNow()
         };
 
         _jobs[jobId] = canceledJob;
@@ -258,8 +258,8 @@ public sealed class JobScheduler(
                     Job runningJob = job with
                     {
                         State = JobState.Running,
-                        StartedAt = _timeProvider.GetUtcNow(),
-                        ModifiedAt = _timeProvider.GetUtcNow()
+                        StartedAt = _timeProvider.GetLocalNow(),
+                        ModifiedAt = _timeProvider.GetLocalNow()
                     };
                     _jobs[job.Id] = runningJob;
 
@@ -322,7 +322,7 @@ public sealed class JobScheduler(
                 {
                     Progress = percentage,
                     CurrentOperation = operation,
-                    ModifiedAt = _timeProvider.GetUtcNow()
+                    ModifiedAt = _timeProvider.GetLocalNow()
                 };
                 _jobs[job.Id] = progressJob;
 
@@ -362,8 +362,8 @@ public sealed class JobScheduler(
                 State = JobState.Completed,
                 Progress = 100.0,
                 CurrentOperation = "Complete",
-                CompletedAt = _timeProvider.GetUtcNow(),
-                ModifiedAt = _timeProvider.GetUtcNow()
+                CompletedAt = _timeProvider.GetLocalNow(),
+                ModifiedAt = _timeProvider.GetLocalNow()
             };
             _jobs[job.Id] = completedJob;
 
@@ -382,8 +382,8 @@ public sealed class JobScheduler(
             {
                 State = JobState.Canceled,
                 ErrorMessage = "Operation canceled by user",
-                CompletedAt = _timeProvider.GetUtcNow(),
-                ModifiedAt = _timeProvider.GetUtcNow()
+                CompletedAt = _timeProvider.GetLocalNow(),
+                ModifiedAt = _timeProvider.GetLocalNow()
             };
             _jobs[job.Id] = canceledJob;
 
@@ -405,8 +405,8 @@ public sealed class JobScheduler(
             {
                 State = JobState.Failed,
                 ErrorMessage = ex.Message,
-                CompletedAt = _timeProvider.GetUtcNow(),
-                ModifiedAt = _timeProvider.GetUtcNow()
+                CompletedAt = _timeProvider.GetLocalNow(),
+                ModifiedAt = _timeProvider.GetLocalNow()
             };
             _jobs[job.Id] = failedJob;
 

--- a/src/S7Tools/Services/Time/TimeProvider.cs
+++ b/src/S7Tools/Services/Time/TimeProvider.cs
@@ -1,0 +1,15 @@
+using S7Tools.Core.Services.Interfaces;
+
+namespace S7Tools.Services.Time;
+
+/// <summary>
+/// Default implementation of <see cref="ITimeProvider"/> using system time.
+/// </summary>
+public class TimeProvider : ITimeProvider
+{
+    /// <inheritdoc />
+    public DateTime GetUtcNow() => DateTime.UtcNow;
+
+    /// <inheritdoc />
+    public DateTime GetLocalNow() => DateTime.Now; // Or DateTime.UtcNow.ToLocalTime()
+}

--- a/src/S7Tools/ViewModels/Controls/SerialPortDiscoveryViewModel.cs
+++ b/src/S7Tools/ViewModels/Controls/SerialPortDiscoveryViewModel.cs
@@ -193,7 +193,7 @@ public sealed class SerialPortDiscoveryViewModel : ViewModelBase, IDisposable
         set => this.RaiseAndSetIfChanged(ref _accessiblePortsCount, value);
     }
 
-    private DateTime _lastScanTime = DateTime.Now;
+    private DateTime _lastScanTime = DateTime.UtcNow.ToLocalTime();
     /// <summary>
     /// Gets or sets the timestamp of the last scan.
     /// </summary>
@@ -447,7 +447,7 @@ public sealed class SerialPortDiscoveryViewModel : ViewModelBase, IDisposable
                 IsScanning = true;
                 StatusMessage = UIStrings.Status_ScanningForPorts;
             });
-            DateTime startTime = DateTime.Now;
+            DateTime startTime = DateTime.UtcNow;
 
             _scanCancellationTokenSource = new CancellationTokenSource();
             CancellationToken cancellationToken = _scanCancellationTokenSource.Token;
@@ -475,7 +475,7 @@ public sealed class SerialPortDiscoveryViewModel : ViewModelBase, IDisposable
                     PortType = portType,
                     PortTypeDisplay = GetPortTypeDisplay(portType),
                     IsAccessible = !CheckAccessibility || await _portService.IsPortAccessibleAsync(portName, 1000, cancellationToken),
-                    LastChecked = DateTime.Now
+                    LastChecked = DateTime.UtcNow.ToLocalTime()
                 };
 
                 // Get additional port information if accessible
@@ -517,8 +517,8 @@ public sealed class SerialPortDiscoveryViewModel : ViewModelBase, IDisposable
                 ApplyFiltersToDiscoveredPorts();
 
                 // Update statistics
-                DateTime endTime = DateTime.Now;
-                LastScanTime = endTime;
+                DateTime endTime = DateTime.UtcNow;
+                LastScanTime = endTime.ToLocalTime();
                 LastScanDuration = endTime - startTime;
                 TotalPortsFound = DiscoveredPorts.Count;
                 AccessiblePortsCount = DiscoveredPorts.Count(p => p.IsAccessible);
@@ -610,7 +610,7 @@ public sealed class SerialPortDiscoveryViewModel : ViewModelBase, IDisposable
             bool isAccessible = await _portService.IsPortAccessibleAsync(portName).ConfigureAwait(false);
 
             SelectedPort.IsAccessible = isAccessible;
-            SelectedPort.LastChecked = DateTime.Now;
+            SelectedPort.LastChecked = DateTime.UtcNow.ToLocalTime();
 
             if (isAccessible)
             {
@@ -664,7 +664,7 @@ public sealed class SerialPortDiscoveryViewModel : ViewModelBase, IDisposable
             bool success = await _portService.ApplyConfigurationAsync(SelectedPort.PortName, defaultConfig);
 
             SelectedPort.LastTestResult = success ? "Success" : "Failed";
-            SelectedPort.LastTested = DateTime.Now;
+            SelectedPort.LastTested = DateTime.UtcNow.ToLocalTime();
 
             StatusMessage = success
                 ? $"Port {SelectedPort.PortName} test successful"
@@ -706,7 +706,7 @@ public sealed class SerialPortDiscoveryViewModel : ViewModelBase, IDisposable
             }
 
             // Show save file dialog
-            string defaultFileName = $"SerialPortScan_{DateTime.Now:yyyyMMdd_HHmmss}.json";
+            string defaultFileName = $"SerialPortScan_{DateTime.UtcNow.ToLocalTime():yyyyMMdd_HHmmss}.json";
             string? filePath = await _fileDialogService.ShowSaveFileDialogAsync(
                 "Export Scan Results",
                 "JSON files (*.json)|*.json|Text files (*.txt)|*.txt|All files (*.*)|*.*",
@@ -722,7 +722,7 @@ public sealed class SerialPortDiscoveryViewModel : ViewModelBase, IDisposable
             // Prepare export data
             var exportData = new
             {
-                ExportDate = DateTime.Now,
+                ExportDate = DateTime.UtcNow.ToLocalTime(),
                 TotalPortsFound = DiscoveredPorts.Count,
                 Ports = DiscoveredPorts.Select(p => new
                 {
@@ -1104,7 +1104,7 @@ public class SerialPortInfo : ReactiveObject
         set => this.RaiseAndSetIfChanged(ref _serialNumber, value);
     }
 
-    private DateTime _lastChecked = DateTime.Now;
+    private DateTime _lastChecked = DateTime.UtcNow.ToLocalTime();
     /// <summary>
     /// Gets or sets the last checked timestamp.
     /// </summary>
@@ -1140,7 +1140,7 @@ public class SerialPortInfo : ReactiveObject
 /// </summary>
 public class ScanResult : ReactiveObject
 {
-    private DateTime _scanTime = DateTime.Now;
+    private DateTime _scanTime = DateTime.UtcNow.ToLocalTime();
     /// <summary>
     /// Gets or sets the scan timestamp.
     /// </summary>

--- a/src/S7Tools/ViewModels/Dialogs/DuplicateMemoryRegionProfileDialogViewModel.cs
+++ b/src/S7Tools/ViewModels/Dialogs/DuplicateMemoryRegionProfileDialogViewModel.cs
@@ -401,7 +401,7 @@ public class DuplicateMemoryRegionProfileDialogViewModel : ViewModelBase, IDispo
         }
 
         // Last resort - add timestamp
-        string timestamp = DateTime.Now.ToString(DateTimeFormats.FileTimestamp);
+        string timestamp = DateTime.UtcNow.ToLocalTime().ToString(DateTimeFormats.FileTimestamp);
         return $"{baseName} Copy {timestamp}";
     }
 

--- a/src/S7Tools/ViewModels/Jobs/JobsManagementViewModel.cs
+++ b/src/S7Tools/ViewModels/Jobs/JobsManagementViewModel.cs
@@ -973,8 +973,8 @@ public class JobsManagementViewModel : ProfileManagementViewModelBase<JobProfile
 
             // Reset ID for import (will be assigned new ID)
             importedJob.Id = 0;
-            importedJob.CreatedAt = DateTime.Now;
-            importedJob.ModifiedAt = DateTime.Now;
+            importedJob.CreatedAt = DateTime.UtcNow;
+            importedJob.ModifiedAt = DateTime.UtcNow;
 
             // Add the imported job
             JobProfile addedJob = await _jobManager.CreateAsync(importedJob);
@@ -1151,7 +1151,7 @@ public class JobsManagementViewModel : ProfileManagementViewModelBase<JobProfile
             }
 
             // Show date/time picker dialog using input dialog
-            string currentTime = DateTime.Now.AddMinutes(5).ToString(S7Tools.Constants.AppConstants.StandardUserInputDateFormat);
+            string currentTime = DateTime.UtcNow.ToLocalTime().AddMinutes(5).ToString(S7Tools.Constants.AppConstants.StandardUserInputDateFormat);
             Models.InputResult inputResult = await _dialogService.ShowInputAsync(
                 "Schedule Task",
                 $"Enter the scheduled execution time for job '{SelectedProfile.Name}':\n\nFormat: {S7Tools.Constants.AppConstants.StandardUserInputDateFormat} (24-hour format)",
@@ -1176,7 +1176,7 @@ public class JobsManagementViewModel : ProfileManagementViewModelBase<JobProfile
                 return;
             }
 
-            DateTime validationTime = DateTime.Now;
+            DateTime validationTime = DateTime.UtcNow;
             // Check if scheduled time is in the past (allow 1-minute tolerance for "now")
             if (scheduledTime < validationTime.AddMinutes(-1))
             {

--- a/src/S7Tools/ViewModels/Layout/MainWindowViewModel.cs
+++ b/src/S7Tools/ViewModels/Layout/MainWindowViewModel.cs
@@ -454,7 +454,7 @@ public class MainWindowViewModel : ViewModelBase, IDisposable
     {
         try
         {
-            string message = $"This is a {levelName} level log message generated at {DateTime.Now}";
+            string message = $"This is a {levelName} level log message generated at {DateTime.UtcNow.ToLocalTime()}";
 
             switch (level)
             {
@@ -496,7 +496,7 @@ public class MainWindowViewModel : ViewModelBase, IDisposable
     {
         try
         {
-            string exportText = "Log Export - " + DateTime.Now.ToString(DateTimeFormats.LongDateTime);
+            string exportText = "Log Export - " + DateTime.UtcNow.ToLocalTime().ToString(DateTimeFormats.LongDateTime);
             await _clipboardService.SetTextAsync(exportText);
             StatusMessage = UIStrings.LogExportCopied;
             _logger.LogInformation("Log export copied to clipboard");

--- a/src/S7Tools/ViewModels/Layout/SettingsManagementViewModel.cs
+++ b/src/S7Tools/ViewModels/Layout/SettingsManagementViewModel.cs
@@ -34,7 +34,7 @@ public class SettingsManagementViewModel : ReactiveObject
     private bool _showLogLevelInLogs = true;
     private string _settingsStatusMessage = UIStrings.Status_SettingsReady;
     private string _currentSettingsFilePath = string.Empty;
-    private DateTime _settingsLastModified = DateTime.Now;
+    private DateTime _settingsLastModified = DateTime.UtcNow.ToLocalTime();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SettingsManagementViewModel"/> class for design-time.
@@ -335,11 +335,11 @@ public class SettingsManagementViewModel : ReactiveObject
             try
             {
                 var fileInfo = new System.IO.FileInfo(CurrentSettingsFilePath);
-                SettingsLastModified = fileInfo.Exists ? fileInfo.LastWriteTime : DateTime.Now;
+                SettingsLastModified = fileInfo.Exists ? fileInfo.LastWriteTime : DateTime.UtcNow.ToLocalTime();
             }
             catch
             {
-                SettingsLastModified = DateTime.Now;
+                SettingsLastModified = DateTime.UtcNow.ToLocalTime();
             }
 
             _logger.LogDebug("Settings loaded from service");
@@ -375,7 +375,7 @@ public class SettingsManagementViewModel : ReactiveObject
             await _settingsService.SaveUserSettingsAsync(userSettings);
 
             SettingsStatusMessage = UIStrings.Status_SettingsSavedSuccessfully;
-            SettingsLastModified = DateTime.Now;
+            SettingsLastModified = DateTime.UtcNow.ToLocalTime();
             _logger.LogInformation("Settings saved to {Path}", CurrentSettingsFilePath);
         }
         catch (Exception ex)
@@ -399,7 +399,7 @@ public class SettingsManagementViewModel : ReactiveObject
             RefreshFromSettings();
 
             SettingsStatusMessage = UIStrings.Status_SettingsLoadedSuccessfully;
-            SettingsLastModified = DateTime.Now;
+            SettingsLastModified = DateTime.UtcNow.ToLocalTime();
             _logger.LogInformation("Settings loaded from {Path}", CurrentSettingsFilePath);
         }
         catch (Exception ex)
@@ -585,7 +585,7 @@ public class SettingsManagementViewModel : ReactiveObject
 
             _logger.LogInformation("Settings imported from JSON successfully");
             SettingsStatusMessage = UIStrings.Status_SettingsImportedSuccessfully;
-            SettingsLastModified = DateTime.Now;
+            SettingsLastModified = DateTime.UtcNow.ToLocalTime();
 
             return true;
         }

--- a/src/S7Tools/ViewModels/Pages/LoggingTestViewModel.cs
+++ b/src/S7Tools/ViewModels/Pages/LoggingTestViewModel.cs
@@ -260,7 +260,7 @@ public sealed class LoggingTestViewModel : ViewModelBase, IDisposable
     /// <param name="logLevel">The log level to test.</param>
     private void TestLogWithLevel(LogLevel logLevel)
     {
-        string message = $"Test {logLevel} log message at {DateTime.Now:HH:mm:ss}";
+        string message = $"Test {logLevel} log message at {DateTime.UtcNow.ToLocalTime():HH:mm:ss}";
 
 
         _logger.Log(logLevel, message);
@@ -276,7 +276,7 @@ public sealed class LoggingTestViewModel : ViewModelBase, IDisposable
         try
         {
             // For now, just show a message. Full implementation would export actual logs.
-            string exportedLogs = $"Log export requested at {DateTime.Now.ToString(DateTimeFormats.LongDateTime)}";
+            string exportedLogs = $"Log export requested at {DateTime.UtcNow.ToLocalTime().ToString(DateTimeFormats.LongDateTime)}";
             await _clipboardService.SetTextAsync(exportedLogs);
             StatusMessage = UIStrings.Status_LogsExportedToClipboard;
             LastButtonPressed = "Export";

--- a/src/S7Tools/ViewModels/Settings/LoggingSettingsViewModel.cs
+++ b/src/S7Tools/ViewModels/Settings/LoggingSettingsViewModel.cs
@@ -140,7 +140,7 @@ public class LoggingSettingsViewModel : ViewModelBase
         set => this.RaiseAndSetIfChanged(ref _currentSettingsFilePath, value);
     }
 
-    private DateTime _settingsLastModified = DateTime.Now;
+    private DateTime _settingsLastModified = DateTime.UtcNow.ToLocalTime();
     public DateTime SettingsLastModified
     {
         get => _settingsLastModified;
@@ -182,11 +182,11 @@ public class LoggingSettingsViewModel : ViewModelBase
         try
         {
             var fileInfo = new System.IO.FileInfo(CurrentSettingsFilePath);
-            SettingsLastModified = fileInfo.Exists ? fileInfo.LastWriteTime : DateTime.Now;
+            SettingsLastModified = fileInfo.Exists ? fileInfo.LastWriteTime : DateTime.UtcNow.ToLocalTime();
         }
         catch
         {
-            SettingsLastModified = DateTime.Now;
+            SettingsLastModified = DateTime.UtcNow.ToLocalTime();
         }
     }
 

--- a/src/S7Tools/ViewModels/Tasks/TaskDetailsViewModel.cs
+++ b/src/S7Tools/ViewModels/Tasks/TaskDetailsViewModel.cs
@@ -1205,7 +1205,7 @@ public class TaskDetailsViewModel : ViewModelBase, IDisposable
                 CancellationToken.None);
 
             // Save the dumped data to the output file
-            string outputFile = Path.Combine(jobProfile.OutputPath, $"dump_{DateTime.Now:yyyyMMdd_HHmmss}.bin");
+            string outputFile = Path.Combine(jobProfile.OutputPath, $"dump_{DateTime.UtcNow.ToLocalTime():yyyyMMdd_HHmmss}.bin");
             await File.WriteAllBytesAsync(outputFile, dumpedData);
 
             ManualProcessProgress = 100;
@@ -1234,7 +1234,7 @@ public class TaskDetailsViewModel : ViewModelBase, IDisposable
         {
             foreach (S7Tools.Core.Models.LogModel item in args.NewItems)
             {
-                _logUpdater.Enqueue((logType, new LogEntry { Timestamp = item.Timestamp, Level = item.Level.ToString(), Category = item.Category, Message = item.Message }));
+                _logUpdater.Enqueue((logType, new LogEntry { Timestamp = item.Timestamp.ToLocalTime(), Level = item.Level.ToString(), Category = item.Category, Message = item.Message }));
             }
         }
         else if (sender is S7Tools.Infrastructure.Logging.Core.Storage.TaskLogDataStore dataStore)
@@ -1260,7 +1260,7 @@ public class TaskDetailsViewModel : ViewModelBase, IDisposable
                 collection.Clear();
                 foreach (LogModel item in dataStore)
                 {
-                    collection.Add(new S7Tools.Models.LogEntry { Timestamp = item.Timestamp, Level = item.Level.ToString(), Category = item.Category, Message = item.Message });
+                    collection.Add(new S7Tools.Models.LogEntry { Timestamp = item.Timestamp.ToLocalTime(), Level = item.Level.ToString(), Category = item.Category, Message = item.Message });
                 }
             });
         }

--- a/src/S7Tools/ViewModels/Tasks/TaskManagerViewModel.cs
+++ b/src/S7Tools/ViewModels/Tasks/TaskManagerViewModel.cs
@@ -335,7 +335,7 @@ public class TaskManagerViewModel : ViewModelBase, IDisposable
     }
 
     // Last update timestamp for UI display
-    private DateTime _lastUpdated = DateTime.Now;
+    private DateTime _lastUpdated = DateTime.UtcNow.ToLocalTime();
 
     /// <summary>
     /// Gets the timestamp of the last task list update.
@@ -639,7 +639,7 @@ public class TaskManagerViewModel : ViewModelBase, IDisposable
                 MergeCollection(FinishedTasks, tasksByState[TaskDisplayState.Finished].SelectMany(x => x));
 
                 UpdateStatistics();
-                LastUpdated = DateTime.Now;
+                LastUpdated = DateTime.UtcNow.ToLocalTime();
             });
         }
         catch (Exception ex)
@@ -891,7 +891,7 @@ public class TaskManagerViewModel : ViewModelBase, IDisposable
         {
             // TODO: Show schedule dialog to get date/time
             // For now, schedule for 5 minutes from now as a placeholder
-            DateTime scheduledTime = DateTime.Now.AddMinutes(5);
+            DateTime scheduledTime = DateTime.UtcNow.ToLocalTime().AddMinutes(5);
 
             IsLoading = true;
             StatusMessage = UIStrings.Status_SchedulingTask;


### PR DESCRIPTION
### **User description**
# Code Review Fixes - Pull Request

## Summary

Implements **11 fixes** from comprehensive code review, addressing critical bugs, race conditions, and code quality improvements.

### Fixes Breakdown
- ✅ **4 Critical fixes** - Race conditions, DateTime consistency, shutdown timeout
- ✅ **4 High-priority fixes** - UI progress, queue bounds, logging improvements  
- ✅ **3 Medium-priority fixes** - Code quality and consistency

---

## Critical Fixes

### C-1: Process Disposal Race Condition
**File**: `SocatService.cs:L1271-1290`

**Problem**: `Process.Dispose()` in Exited event handler created race condition with `StopSocatByIdAsync`, causing `ObjectDisposedException`.

**Solution**: Removed disposal from event handler; cleanup now handled by explicit stop or garbage collection.

**Impact**: Eliminates crashes during concurrent process operations.

---

### C-2: DateTime Consistency
**File**: `SocatService.cs:L1594, L1599`

**Problem**: Used `DateTime.Now` instead of `DateTime.UtcNow`, violating UTC-first policy.

**Solution**: Changed to `DateTime.UtcNow` for consistency.

**Impact**: Prevents timezone-related bugs in task comparisons.

---

### C-3: Duplicate Debug Logs
**File**: `SocatService.cs:L376-379`

**Problem**: Merge conflict left duplicate log statements.

**Solution**: Removed duplicates.

**Impact**: Cleaner code and logs.

---

### C-5: Graceful Shutdown Timeout
**File**: `EnhancedTaskScheduler.cs:L605-631`

**Problem**: `StopAsync` could wait indefinitely for running tasks.

**Solution**: Added 30-second timeout with warning log.

**Impact**: Application now exits within 30s even with running tasks.

---

## High-Priority Fixes

### H-1: Progress Reporting
**File**: `BootloaderService.cs:L210-215`

**Problem**: Commented-out code caused UI progress bar to freeze at 20%.

**Solution**: Uncommented `WaitWithProgressAsync` for power cycle stage.

**Impact**: Smooth progress updates 20% → 25%.

---

### H-2: Handshake Attempt Count
**File**: `PlcProtocolHandler.cs:L56-92`

**Problem**: Magic number 50, error message said "100 attempts".

**Solution**: Added `MaxHandshakeAttempts = 50` constant, fixed error message.

**Impact**: Clear errors, no magic numbers.

---

### H-6: Bounded Queue Size
**File**: `EnhancedTaskScheduler.cs:L177-188`

**Problem**: Unbounded `ConcurrentQueue` could exhaust memory.

**Solution**: Added 1000 task limit with error handling.

**Impact**: Protection against memory exhaustion.

---

### H-8: Excessive Emoji Logging
**File**: `SocatService.cs:L637-664`

**Problem**: Information-level logs with emojis in hot path.

**Solution**: Changed to Debug level, removed emojis.

**Impact**: Cleaner production logs.

---

## Medium-Priority Fixes

### M-2: CancellationToken Consistency
**File**: `SocatService.cs:L1509`

**Solution**: Added `CancellationToken` parameter to `UpdateProcessStatusesAsync`.

**Impact**: Consistent async pattern.

---

### M-3: Execution Times Bounds
**File**: `EnhancedTaskScheduler.cs:L916-923`

**Solution**: Added clarifying comment for bounds enforcement (already implemented).

**Impact**: Code clarity.

---

### M-5: Unnecessary Awaits
**File**: `EnhancedTaskScheduler.cs:L810`

**Solution**: Removed `await Task.CompletedTask`.

**Impact**: Cleaner code.

---

## Files Modified

- `src/S7Tools/Services/SocatService.cs` (5 fixes)
- `src/S7Tools/Services/Tasking/EnhancedTaskScheduler.cs` (4 fixes)
- `src/S7Tools/Services/Adapters/Plc/PlcProtocolHandler.cs` (1 fix)
- `src/S7Tools/Services/Bootloader/BootloaderService.cs` (1 fix)

---

## Testing Checklist

### Automated
- [ ] Unit tests pass
- [ ] Integration tests pass

### Manual Verification
- [ ] Process start/stop under load (C-1)
- [ ] Shutdown with long-running task (C-5)
- [ ] Progress bar updates smoothly (H-1)
- [ ] Queue overflow behavior (H-6)

---

## Risk Assessment

✅ **Low Risk**: All changes are targeted, well-understood improvements  
✅ **No Breaking Changes**: Backwards compatible  
✅ **Easy Rollback**: Simple fixes, easy to revert if needed

---

## Related Documentation

See comprehensive analysis in code review artifacts:
- `code_review_findings.md` - All 22 identified issues
- `fix_implementation_summary.md` - Complete implementation details
- `walkthrough.md` - Review methodology

---

## Commits

1. `eb05d33` - Critical & high-priority fixes (6 items)
2. `8de0cf3` - Remaining high-priority fixes (2 items)
3. `90761e4` - Medium-priority code quality (3 items)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Introduce `ITimeProvider` abstraction for testable, consistent time handling across application

- Replace scattered `DateTime.Now`/`DateTime.UtcNow` calls with provider-based approach

- Fix race condition in process disposal and add graceful shutdown timeout (30s)

- Add bounded queue size (1000 tasks) to prevent memory exhaustion in task scheduler

- Improve logging by reducing emoji usage and changing info-level logs to debug level


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DateTime Calls<br/>Scattered Across Code"] -->|"Abstracted via"| B["ITimeProvider<br/>Interface"]
  B -->|"Injected into"| C["Services<br/>TaskExecution<br/>Logging"]
  C -->|"Enables"| D["Testability<br/>Consistency<br/>Control"]
  E["Task Queue<br/>Unbounded"] -->|"Add Limit"| F["MaxQueueSize<br/>1000 Tasks"]
  F -->|"Prevents"| G["Memory<br/>Exhaustion"]
  H["Process Disposal<br/>Race Condition"] -->|"Fix via"| I["Remove Dispose<br/>from Handler"]
  I -->|"Improves"| J["Stability"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>14 files</summary><table>
<tr>
  <td><strong>ITimeProvider.cs</strong><dd><code>New time provider interface for abstraction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-a3f5a4e5de389876fe666499b8f773267185c3bb6880c34c8362578d4e3e7342">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TimeProvider.cs</strong><dd><code>Default implementation of time provider</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-766172b543fa40b857c3a378ec9f1fb3f2c8e1c26aa0d6d9c8c580f8ed90b862">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TaskExecution.cs</strong><dd><code>Add time provider support and local time handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-cb2584af332962dcd5e83f0bba1ab149121f36c5bf179e0b5eaf038d66a99704">+47/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LoggingServiceCollectionExtensions.cs</strong><dd><code>Inject time provider into logger providers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-6fee4e787388541c239cdefbb2ed06f8ae3434669874ed92e631762ae3b7b3d5">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DataStoreLogger.cs</strong><dd><code>Use time provider for log timestamps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-0e0ac1b26cd6a6bf96905a1310ba87b821adb9d72fc68a5d078d962a93777b6f">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DataStoreLoggerProvider.cs</strong><dd><code>Add time provider dependency injection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-64a7f8db87000f648bef3965c28414f309549f40f238aa648961b09ced4a1a4a">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ServiceCollectionExtensions.cs</strong><dd><code>Register time provider and inject into services</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-4e3ccbcb57e037a419f4888004cb126160ba868c1e537f551ae87d57eeb6e805">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BootloaderService.cs</strong><dd><code>Inject time provider and use for timestamp generation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-54c3498ed946acb94a5a7f8520b00a8b0284395f77e3f3e53bba53d4da7c32d1">+10/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>JobManager.cs</strong><dd><code>Inject time provider for job timestamp generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-29f3bae6b6b3b8d0746458e752e05ea2c0dbc15aa26c2d1efb10075f6b2aa2b1">+9/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LogExportService.cs</strong><dd><code>Use time provider for export timestamps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-8292f2975ed6e22a051cca5d941971537d4d31e21216b19b24c79217c92ee992">+11/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TaskLoggerFactory.cs</strong><dd><code>Inject time provider and add error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-32a3b60236d7ee68208a9e3e10a5a41fcb775e8cb60cacd99143778b9d87fd77">+144/-114</a></td>

</tr>

<tr>
  <td><strong>SerialPortService.cs</strong><dd><code>Inject time provider for port status timestamps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-c8dfee8236f319914210e9e30124717a69eba43b3b9610218c4c60c92571329c">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>EnhancedTaskScheduler.cs</strong><dd><code>Add time provider, bounded queue, graceful shutdown timeout</code></dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-1d948d301664f05b0c3b249e765da396f133695ba45dec7542683d27ab9bcf3a">+115/-42</a></td>

</tr>

<tr>
  <td><strong>JobScheduler.cs</strong><dd><code>Inject time provider and use for job timestamps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-b97fc34a11b290f8b62578c84a418d93c9bf8132579ba8529d89a91758298cfd">+19/-17</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>17 files</summary><table>
<tr>
  <td><strong>TaskLogger.cs</strong><dd><code>Fix DateTime.Now to DateTime.UtcNow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-929d51d548222de8e75bf93760477e80ed906a0898b2ee71188e392881da858e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LogModel.cs</strong><dd><code>Fix DateTime.Now to DateTime.UtcNow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-aebff87432fc2417e5e086d4cf0f8b63fc4ff82b773920f0aa511fce6cb60974">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>UnifiedLogger.cs</strong><dd><code>Fix DateTime.Now to DateTime.UtcNow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-ae58be476bf69545e71fe036e2fd30354986c3755a105d770c33acc2d743819c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PlcProtocolHandler.cs</strong><dd><code>Add MaxHandshakeAttempts constant and fix error message</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-cb2d68aa991439dec3920ff4c51274791b14a37f7be7a2dc70c095fe281e47a1">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>EnhancedBootloaderService.cs</strong><dd><code>Fix DateTime.Now to UtcNow with local conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-c27a8b91defb18ad13991073a508aa5541827f1a1fc4c3302d6cf6c9867bb1ff">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PathService.cs</strong><dd><code>Fix DateTime.Now to UtcNow with local conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-062c19f217feb540030b1ef6cfdf0c3930f176d824e575b6f7d8e7b814bd2a31">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SocatService.cs</strong><dd><code>Inject time provider, fix race condition, reduce emoji logging</code></dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-78cd47cdeff1b146c9f40c30a1b61f465dff0cdbdca5ad3868ef25a19c1aaebc">+29/-26</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>StructuredLogger.cs</strong><dd><code>Fix DateTime.Now to DateTime.UtcNow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-c2163db255b7725fe2a0aea95b4fb2494ed5814704a87762d0a621491ed5eeb8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SerialPortDiscoveryViewModel.cs</strong><dd><code>Fix DateTime.Now to UtcNow with local conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-59d841ba01f4262e0b650189ccc532f10d2f3a0656f79d7441b4f1b628e79a7a">+11/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>DuplicateMemoryRegionProfileDialogViewModel.cs</strong><dd><code>Fix DateTime.Now to UtcNow with local conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-411bab335b0fbb605ddaaa28f0ddce8d4889b19642d88f44e79b594ddfb5ab8d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>JobsManagementViewModel.cs</strong><dd><code>Fix DateTime.Now to DateTime.UtcNow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-86a3e7e817dead3d0682d6dc0c7ac2b36b68973ba2b2fde09da094a7ba54cd68">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MainWindowViewModel.cs</strong><dd><code>Fix DateTime.Now to UtcNow with local conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-212b59251d37596ad215403eaa5c0d22ae299eb395bf8e3c2948768e2d3d6740">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SettingsManagementViewModel.cs</strong><dd><code>Fix DateTime.Now to UtcNow with local conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-774eb72cfa476c9acc1e0e1873431ffb771cd31984de53ac45e6b74dff3fffd1">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LoggingTestViewModel.cs</strong><dd><code>Fix DateTime.Now to UtcNow with local conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-5fac7939972fe052da86a0574a41f4a0990e9d8eadf3ce5f54d477624bd68a2f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LoggingSettingsViewModel.cs</strong><dd><code>Fix DateTime.Now to UtcNow with local conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-173d6e2198cbbccbe8bf6ca7132b20ba3ba45e16bd4580749b51edc93b5ae808">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TaskDetailsViewModel.cs</strong><dd><code>Fix DateTime.Now to UtcNow with local conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-fa3f508f1f5074342e495de56f6412c2ec5178001061433e6c0544d9611e541e">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TaskManagerViewModel.cs</strong><dd><code>Fix DateTime.Now to UtcNow with local conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-7bdc000c0702c9c81046fbeed21bafa247511c393d3400eb29fab049504a5e86">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>development-standards.md</strong><dd><code>Update documentation to use DateTime.UtcNow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-4b0f1e92d0b06c7b7ae6e87f024e6d7bf6be51c518cb264d1cd7f00523e9affb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>quickstart.md</strong><dd><code>Fix DateTime.Now to DateTime.UtcNow in examples</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-8d1d155d9abbc3317cb01d0b898402bd3d8dd9ba983d254ae24dc3785f16451f">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>research.md</strong><dd><code>Fix DateTime.Now to DateTime.UtcNow in examples</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-9571e44c17481249c17444ee9db956c9dfe03e87c97e22160bf865591d2c526d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong><dd><code>Update documentation examples to use DateTime.UtcNow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-70601a817ba63df06b37c73abc2116e68f5f81996cf625335f66c752909aea95">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>temp_compare</strong></td>
  <td><a href="https://github.com/efargas/S7-Tools/pull/116/files#diff-dd1a7503b492505654d0b0917124bbcee1d0859e78b3e310c82e26f534e4138f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

