### PR TITLE
🧹 Use proper logging for HexViewerViewModel exceptions

### DIFF
--- a/src/S7Tools/ViewModels/Hex/HexViewerViewModel.cs
+++ b/src/S7Tools/ViewModels/Hex/HexViewerViewModel.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Reactive;
 using System.Reactive.Disposables;
 using AvaloniaHex.Document;
+using Microsoft.Extensions.Logging;
 using ReactiveUI;
 using S7Tools.Core.Interfaces;
 using S7Tools.Models.Hex;
@@ -12,6 +13,7 @@ namespace S7Tools.ViewModels.Hex
 {
     public class HexViewerViewModel : ReactiveObject, IDisposable
     {
+        private readonly ILogger<HexViewerViewModel> _logger;
         private IBinaryDocument? _document;
         private string _fileName = string.Empty;
         private long _fileSize;
@@ -19,8 +21,9 @@ namespace S7Tools.ViewModels.Hex
         private long _selectionStart;
         private long _selectionLength;
 
-        public HexViewerViewModel()
+        public HexViewerViewModel(ILogger<HexViewerViewModel> logger)
         {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             CloseFileCommand = ReactiveCommand.Create(CloseFile);
 
             this.WhenAnyValue(x => x.SelectionStart, x => x.SelectionLength)
@@ -65,7 +68,7 @@ namespace S7Tools.ViewModels.Hex
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Fill Error: {ex.Message}");
+                _logger.LogError(ex, "Fill Error");
             }
         }
 
@@ -132,7 +135,7 @@ namespace S7Tools.ViewModels.Hex
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Error opening hex view: {ex.Message}");
+                _logger.LogError(ex, "Error opening hex view");
             }
         }
 
@@ -167,7 +170,7 @@ namespace S7Tools.ViewModels.Hex
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Error updating inspector: {ex.Message}");
+                _logger.LogError(ex, "Error updating inspector");
             }
         }
 

--- a/src/S7Tools/ViewModels/Hex/HexViewerViewModel.cs
+++ b/src/S7Tools/ViewModels/Hex/HexViewerViewModel.cs
@@ -21,6 +21,13 @@ namespace S7Tools.ViewModels.Hex
         private long _selectionStart;
         private long _selectionLength;
 
+        /// <summary>
+        /// Design-time constructor.
+        /// </summary>
+        public HexViewerViewModel() : this(Microsoft.Extensions.Logging.Abstractions.NullLogger<HexViewerViewModel>.Instance)
+        {
+        }
+
         public HexViewerViewModel(ILogger<HexViewerViewModel> logger)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -68,7 +75,7 @@ namespace S7Tools.ViewModels.Hex
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Fill Error");
+                _logger.LogError(ex, "Fill Error at {SelectionStart} with length {SelectionLength} (PatternLength: {PatternLength})", SelectionStart, SelectionLength, pattern?.Length ?? 0);
             }
         }
 
@@ -135,7 +142,7 @@ namespace S7Tools.ViewModels.Hex
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error opening hex view");
+                _logger.LogError(ex, "Error opening hex view for {Path}", path);
             }
         }
 
@@ -170,7 +177,7 @@ namespace S7Tools.ViewModels.Hex
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error updating inspector");
+                _logger.LogError(ex, "Error updating inspector at {SelectionStart} with length {SelectionLength}", SelectionStart, SelectionLength);
             }
         }
 


### PR DESCRIPTION
🎯 **What:** Replaced `Console.WriteLine` with `ILogger<HexViewerViewModel>` in `HexViewerViewModel.cs`.
💡 **Why:** Improves maintainability and follows the project's established logging patterns by using structured logging and dependency injection.
✅ **Verification:** Verified the code changes manually. Confirmed that `HexViewerViewModel` is instantiated via Dependency Injection in `ServiceCollectionExtensions.cs` and `FileMemoryDumpViewModel.cs`, making the constructor change safe.
✨ **Result:** Proper error logging with stack traces is now available for the Hex Viewer component.

---
*PR created automatically by Jules for task [3693195773270401493](https://jules.google.com/task/3693195773270401493) started by @efargas*