### PR TITLE
Address PR feedback on FeatureViewModel template

### DIFF
--- a/docs/templates/ui-integration/FeatureViewModel.template.cs
+++ b/docs/templates/ui-integration/FeatureViewModel.template.cs
@@ -25,7 +25,10 @@ public class [FEATURE_NAME]ViewModel : ViewModelBase, IDisposable
     private ObservableCollection<string> _categories = new();
 
     // Main content state
-    private object? _selectedContentViewModel;
+    private [FEATURE_NAME]OverviewViewModel? _overviewVm;
+    private [FEATURE_NAME]DetailsViewModel? _detailsVm;
+    private [FEATURE_NAME]SettingsViewModel? _settingsVm;
+    private ViewModelBase? _selectedContentViewModel;
     private string _statusMessage = string.Empty;
     private bool _isLoading;
 
@@ -90,7 +93,7 @@ public class [FEATURE_NAME]ViewModel : ViewModelBase, IDisposable
     /// Gets or sets the ViewModel for the main content area.
     /// This switches based on sidebar selection.
     /// </summary>
-    public object? SelectedContentViewModel
+    public ViewModelBase? SelectedContentViewModel
     {
         get => _selectedContentViewModel;
         set => this.RaiseAndSetIfChanged(ref _selectedContentViewModel, value);
@@ -169,30 +172,27 @@ public class [FEATURE_NAME]ViewModel : ViewModelBase, IDisposable
     }
 
     /// <summary>
-    /// Creates the overview ViewModel for the main content area.
+    /// Creates or returns the cached overview ViewModel for the main content area.
     /// </summary>
-    private object Create[FEATURE_NAME]OverviewViewModel()
+    private [FEATURE_NAME]OverviewViewModel Create[FEATURE_NAME]OverviewViewModel()
     {
-        // Create and return the overview ViewModel
-        return new [FEATURE_NAME]OverviewViewModel();
+        return _overviewVm ??= new [FEATURE_NAME]OverviewViewModel();
     }
 
     /// <summary>
-    /// Creates the details ViewModel for the main content area.
+    /// Creates or returns the cached details ViewModel for the main content area.
     /// </summary>
-    private object Create[FEATURE_NAME]DetailsViewModel()
+    private [FEATURE_NAME]DetailsViewModel Create[FEATURE_NAME]DetailsViewModel()
     {
-        // Create and return the details ViewModel
-        return new [FEATURE_NAME]DetailsViewModel();
+        return _detailsVm ??= new [FEATURE_NAME]DetailsViewModel();
     }
 
     /// <summary>
-    /// Creates the settings ViewModel for the main content area.
+    /// Creates or returns the cached settings ViewModel for the main content area.
     /// </summary>
-    private object Create[FEATURE_NAME]SettingsViewModel()
+    private [FEATURE_NAME]SettingsViewModel Create[FEATURE_NAME]SettingsViewModel()
     {
-        // Create and return the settings ViewModel
-        return new [FEATURE_NAME]SettingsViewModel();
+        return _settingsVm ??= new [FEATURE_NAME]SettingsViewModel();
     }
 
     /// <summary>
@@ -246,6 +246,12 @@ public class [FEATURE_NAME]ViewModel : ViewModelBase, IDisposable
         if (disposing)
         {
             _disposables.Dispose();
+
+            // Dispose cached ViewModels if they implement IDisposable
+            (_overviewVm as IDisposable)?.Dispose();
+            (_detailsVm as IDisposable)?.Dispose();
+            (_settingsVm as IDisposable)?.Dispose();
+
             _logger.LogDebug("[FEATURE_NAME]ViewModel disposed");
         }
 

--- a/docs/templates/ui-integration/FeatureViewModel.template.cs
+++ b/docs/templates/ui-integration/FeatureViewModel.template.cs
@@ -173,9 +173,8 @@ public class [FEATURE_NAME]ViewModel : ViewModelBase, IDisposable
     /// </summary>
     private object Create[FEATURE_NAME]OverviewViewModel()
     {
-        // TODO: Create and return the overview ViewModel
-        // Example: return new [FEATURE_NAME]OverviewViewModel();
-        return new ViewModelBase(); // Placeholder
+        // Create and return the overview ViewModel
+        return new [FEATURE_NAME]OverviewViewModel();
     }
 
     /// <summary>
@@ -183,8 +182,8 @@ public class [FEATURE_NAME]ViewModel : ViewModelBase, IDisposable
     /// </summary>
     private object Create[FEATURE_NAME]DetailsViewModel()
     {
-        // TODO: Create and return the details ViewModel
-        return new ViewModelBase(); // Placeholder
+        // Create and return the details ViewModel
+        return new [FEATURE_NAME]DetailsViewModel();
     }
 
     /// <summary>
@@ -192,8 +191,8 @@ public class [FEATURE_NAME]ViewModel : ViewModelBase, IDisposable
     /// </summary>
     private object Create[FEATURE_NAME]SettingsViewModel()
     {
-        // TODO: Create and return the settings ViewModel
-        return new ViewModelBase(); // Placeholder
+        // Create and return the settings ViewModel
+        return new [FEATURE_NAME]SettingsViewModel();
     }
 
     /// <summary>
@@ -255,3 +254,28 @@ public class [FEATURE_NAME]ViewModel : ViewModelBase, IDisposable
 
     #endregion
 }
+
+#region Mock ViewModels
+
+/// <summary>
+/// Mock Overview ViewModel for design-time and initial implementation.
+/// </summary>
+public class [FEATURE_NAME]OverviewViewModel : ViewModelBase
+{
+}
+
+/// <summary>
+/// Mock Details ViewModel for design-time and initial implementation.
+/// </summary>
+public class [FEATURE_NAME]DetailsViewModel : ViewModelBase
+{
+}
+
+/// <summary>
+/// Mock Settings ViewModel for design-time and initial implementation.
+/// </summary>
+public class [FEATURE_NAME]SettingsViewModel : ViewModelBase
+{
+}
+
+#endregion


### PR DESCRIPTION
I have addressed the Qodo code review suggestions by:
1. Making the mock ViewModel types public so they work better with XAML compiled bindings and type resolution.
2. Implementing a caching pattern for the content ViewModels within the FeatureViewModel template, ensuring that state is preserved when switching between categories and that resources are properly disposed of when the main ViewModel is destroyed.

---
*PR created automatically by Jules for task [8714801939707767319](https://jules.google.com/task/8714801939707767319) started by @efargas*