### PR TITLE
🔒 Fix Command Injection in SerialPortDiscoveryService and ShellExecutor

### DIFF
--- a/src/S7Tools.Core/Services/Shell/IShellCommandExecutor.cs
+++ b/src/S7Tools.Core/Services/Shell/IShellCommandExecutor.cs
@@ -38,4 +38,14 @@ public interface IShellCommandExecutor
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A list of child process IDs.</returns>
     Task<List<int>> GetChildProcessesAsync(int parentPid, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Executes a command directly without a shell.
+    /// </summary>
+    /// <param name="fileName">The executable to run.</param>
+    /// <param name="arguments">The arguments to pass to the executable.</param>
+    /// <param name="timeoutMs">Timeout in milliseconds (optional).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The result of the execution.</returns>
+    Task<ShellCommandResult> ExecuteDirectAsync(string fileName, IEnumerable<string> arguments, int timeoutMs = -1, CancellationToken cancellationToken = default);
 }

--- a/src/S7Tools/Services/SerialPort/SerialPortDiscoveryService.cs
+++ b/src/S7Tools/Services/SerialPort/SerialPortDiscoveryService.cs
@@ -173,8 +173,7 @@ public sealed class SerialPortDiscoveryService
             }
 
             // Test accessibility by trying to read port status with stty
-            string command = $"stty -F '{portPath.Replace("'", "'\"'\"'")}' -a";
-            var result = await _shellExecutor.ExecuteCommandWithTimeoutAsync(command, timeoutMs, cancellationToken).ConfigureAwait(false);
+            var result = await _shellExecutor.ExecuteDirectAsync("stty", ["-F", portPath, "-a"], timeoutMs, cancellationToken).ConfigureAwait(false);
             return result.Success;
         }
         catch (Exception ex)
@@ -307,8 +306,7 @@ public sealed class SerialPortDiscoveryService
         try
         {
             // Try to use lsof to check if port is in use
-            string command = $"lsof '{portPath.Replace("'", "'\"'\"'")}'";
-            var result = await _shellExecutor.ExecuteCommandWithTimeoutAsync(command, 2000, cancellationToken).ConfigureAwait(false);
+            var result = await _shellExecutor.ExecuteDirectAsync("lsof", [portPath], 2000, cancellationToken).ConfigureAwait(false);
             return result.Success && !string.IsNullOrWhiteSpace(result.Output);
         }
         catch
@@ -334,64 +332,6 @@ public sealed class SerialPortDiscoveryService
         };
     }
 
-    /// <summary>
-    /// Executes a command and returns the result.
-    /// </summary>
-    /// <param name="command">The command to execute.</param>
-    /// <param name="timeoutMs">The timeout in milliseconds.</param>
-    /// <param name="cancellationToken">Token to cancel the operation.</param>
-    /// <returns>The command execution result.</returns>
-    private async Task<(bool Success, int ExitCode, string StandardOutput, string StandardError)> ExecuteCommandAsync(
-        string command,
-        int timeoutMs,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            using var process = new Process();
-            _logger.LogInformation("Executing: {Command}", command);
-            process.StartInfo.FileName = "/bin/bash";
-            process.StartInfo.Arguments = $"-c \"{command}\"";
-            process.StartInfo.UseShellExecute = false;
-            process.StartInfo.RedirectStandardOutput = true;
-            process.StartInfo.RedirectStandardError = true;
-            process.StartInfo.CreateNoWindow = true;
-
-            var outputBuilder = new StringBuilder();
-            var errorBuilder = new StringBuilder();
-
-            process.OutputDataReceived += (_, e) => { if (e.Data != null) { outputBuilder.AppendLine(e.Data); } };
-            process.ErrorDataReceived += (_, e) => { if (e.Data != null) { errorBuilder.AppendLine(e.Data); } };
-
-            process.Start();
-            process.BeginOutputReadLine();
-            process.BeginErrorReadLine();
-
-            using var timeoutCts = new CancellationTokenSource(timeoutMs);
-            using var combinedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
-
-            try
-            {
-                await process.WaitForExitAsync(combinedCts.Token).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                if (!process.HasExited)
-                {
-                    process.Kill();
-                }
-                throw;
-            }
-
-            bool success = process.ExitCode == 0;
-            return (success, process.ExitCode, outputBuilder.ToString().Trim(), errorBuilder.ToString().Trim());
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to execute command: {Command}", command);
-            return (false, -1, "", ex.Message);
-        }
-    }
 
     /// <summary>
     /// Tries to read a sysfs file and apply the value using the provided action.

--- a/src/S7Tools/Services/Shell/ShellCommandExecutor.cs
+++ b/src/S7Tools/Services/Shell/ShellCommandExecutor.cs
@@ -46,7 +46,7 @@ public sealed class ShellCommandExecutor : IShellCommandExecutor
         try
         {
             // Use pgrep to find child processes on Linux/Unix
-            var result = await ExecuteCommandInternalAsync($"pgrep -P {parentPid}", 5000, cancellationToken).ConfigureAwait(false);
+            var result = await ExecuteDirectAsync("pgrep", ["-P", parentPid.ToString()], 5000, cancellationToken).ConfigureAwait(false);
 
             if (result.Success && !string.IsNullOrWhiteSpace(result.Output))
             {
@@ -67,6 +67,41 @@ public sealed class ShellCommandExecutor : IShellCommandExecutor
         return childPids;
     }
 
+    /// <inheritdoc />
+    public async Task<ShellCommandResult> ExecuteDirectAsync(string fileName, IEnumerable<string> arguments, int timeoutMs = -1, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            throw new ArgumentException("FileName cannot be null or empty.", nameof(fileName));
+        }
+
+        try
+        {
+            _logger.LogTrace("Executing direct command: {FileName} {Arguments}", fileName, string.Join(" ", arguments));
+
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = fileName,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+
+            foreach (string arg in arguments)
+            {
+                startInfo.ArgumentList.Add(arg);
+            }
+
+            return await ExecuteProcessAsync(startInfo, timeoutMs, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error executing direct command: {FileName}", fileName);
+            return new ShellCommandResult(false, -1, string.Empty, ex.Message);
+        }
+    }
+
     private async Task<ShellCommandResult> ExecuteCommandInternalAsync(string command, int timeoutMs, CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(command))
@@ -81,13 +116,27 @@ public sealed class ShellCommandExecutor : IShellCommandExecutor
             var startInfo = new ProcessStartInfo
             {
                 FileName = "/bin/bash",
-                Arguments = $"-c \"{command.Replace("\"", "\\\"")}\"",
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 CreateNoWindow = true
             };
+            startInfo.ArgumentList.Add("-c");
+            startInfo.ArgumentList.Add(command);
 
+            return await ExecuteProcessAsync(startInfo, timeoutMs, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error executing shell command: {Command}", command);
+            return new ShellCommandResult(false, -1, string.Empty, ex.Message);
+        }
+    }
+
+    private async Task<ShellCommandResult> ExecuteProcessAsync(ProcessStartInfo startInfo, int timeoutMs, CancellationToken cancellationToken)
+    {
+        try
+        {
             using var process = new Process { StartInfo = startInfo };
 
             var outputBuilder = new StringBuilder();
@@ -98,7 +147,7 @@ public sealed class ShellCommandExecutor : IShellCommandExecutor
 
             if (!process.Start())
             {
-                _logger.LogError("Failed to start process for command: {Command}", command);
+                _logger.LogError("Failed to start process: {FileName}", startInfo.FileName);
                 return new ShellCommandResult(false, -1, string.Empty, "Failed to start process.");
             }
 
@@ -118,8 +167,8 @@ public sealed class ShellCommandExecutor : IShellCommandExecutor
                 }
                 catch (OperationCanceledException)
                 {
-                    _logger.LogWarning("Command timed out after {Timeout}ms: {Command}", timeoutMs, command);
-                    errorBuilder.AppendLine($"Command timed out after {timeoutMs}ms.");
+                    _logger.LogWarning("Process timed out after {Timeout}ms: {FileName}", timeoutMs, startInfo.FileName);
+                    errorBuilder.AppendLine($"Process timed out after {timeoutMs}ms.");
 
                     try
                     {
@@ -148,7 +197,7 @@ public sealed class ShellCommandExecutor : IShellCommandExecutor
 
             if (exited)
             {
-                _logger.LogTrace("Command completed with exit code {ExitCode}. Output length: {OutLen}, Error length: {ErrLen}",
+                _logger.LogTrace("Process completed with exit code {ExitCode}. Output length: {OutLen}, Error length: {ErrLen}",
                     exitCode, stdout.Length, stderr.Length);
             }
 
@@ -156,7 +205,7 @@ public sealed class ShellCommandExecutor : IShellCommandExecutor
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Unexpected error executing shell command: {Command}", command);
+            _logger.LogError(ex, "Unexpected error during process execution: {FileName}", startInfo.FileName);
             return new ShellCommandResult(false, -1, string.Empty, ex.Message);
         }
     }

--- a/src/S7Tools/Services/SocatService.cs
+++ b/src/S7Tools/Services/SocatService.cs
@@ -905,20 +905,25 @@ public partial class SocatService : ISocatService, IDisposable
     /// <summary>
     /// Executes a system command and returns the result.
     /// </summary>
-    /// <param name="command">The command to execute.</param>
+    /// <param name="fileName">The executable to run.</param>
+    /// <param name="arguments">The arguments to pass to the executable.</param>
     /// <param name="timeoutMs">The timeout in milliseconds.</param>
     /// <param name="cancellationToken">Token to cancel the operation.</param>
     /// <returns>The command execution result.</returns>
-    private async Task<(bool Success, int ExitCode, string StandardOutput, string StandardError)> ExecuteCommandAsync(
-        string command,
+    private async Task<(bool Success, int ExitCode, string StandardOutput, string StandardError)> ExecuteDirectAsync(
+        string fileName,
+        IEnumerable<string> arguments,
         int timeoutMs,
         CancellationToken cancellationToken)
     {
         try
         {
             using var process = new Process();
-            process.StartInfo.FileName = "/bin/bash";
-            process.StartInfo.Arguments = $"-c \"{command}\"";
+            process.StartInfo.FileName = fileName;
+            foreach (string arg in arguments)
+            {
+                process.StartInfo.ArgumentList.Add(arg);
+            }
             process.StartInfo.UseShellExecute = false;
             process.StartInfo.RedirectStandardOutput = true;
             process.StartInfo.RedirectStandardError = true;
@@ -969,12 +974,12 @@ public partial class SocatService : ISocatService, IDisposable
         }
         catch (OperationCanceledException)
         {
-            _logger.LogWarning("Command execution timed out: {Command}", command);
+            _logger.LogWarning("Command execution timed out: {FileName}", fileName);
             return (false, -1, string.Empty, "Command timed out");
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to execute command: {Command}", command);
+            _logger.LogError(ex, "Failed to execute command: {FileName}", fileName);
             return (false, -1, string.Empty, ex.Message);
         }
     }
@@ -996,12 +1001,12 @@ public partial class SocatService : ISocatService, IDisposable
         {
             // Use pgrep to find child processes (portable enough on modern Linux/macOS)
             // -P matches Parent Process ID
-            (bool success, int _, string stdout, string _) = await ExecuteCommandAsync($"pgrep -P {parentId}", 1000, cancellationToken).ConfigureAwait(false);
+            (bool success, int _, string stdout, string _) = await ExecuteDirectAsync("pgrep", ["-P", parentId.ToString()], 1000, cancellationToken).ConfigureAwait(false);
 
             if (!success || string.IsNullOrWhiteSpace(stdout))
             {
                 // Fallback to ps if pgrep fails or returns distinct exit code for "no matches"
-                (success, _, stdout, _) = await ExecuteCommandAsync($"ps -o pid --ppid {parentId} --no-headers", 1000, cancellationToken).ConfigureAwait(false);
+                (success, _, stdout, _) = await ExecuteDirectAsync("ps", ["-o", "pid", "--ppid", parentId.ToString(), "--no-headers"], 1000, cancellationToken).ConfigureAwait(false);
 
                 if (!success || string.IsNullOrWhiteSpace(stdout))
                 {

--- a/tests/S7Tools.Tests/Services/Shell/ShellCommandExecutorVulnerabilityTests.cs
+++ b/tests/S7Tools.Tests/Services/Shell/ShellCommandExecutorVulnerabilityTests.cs
@@ -1,0 +1,69 @@
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using S7Tools.Services.Shell;
+using Xunit;
+using FluentAssertions;
+
+namespace S7Tools.Tests.Services.Shell;
+
+public class ShellCommandExecutorVulnerabilityTests
+{
+    private readonly Mock<ILogger<ShellCommandExecutor>> _mockLogger;
+
+    public ShellCommandExecutorVulnerabilityTests()
+    {
+        _mockLogger = new Mock<ILogger<ShellCommandExecutor>>();
+    }
+
+    [Fact]
+    public async Task ExecuteCommandAsync_WithDoubleQuoteBreakout_ShouldConfirmVulnerability()
+    {
+        // Arrange
+        var executor = new ShellCommandExecutor(_mockLogger.Object);
+        // We try to inject a command that outputs a specific string.
+        // If we can break out of the double quotes, we can execute another command.
+        // The current code does: -c "{command.Replace("\"", "\\\"")}"
+        // Injection: $(echo INJECTED)
+        string maliciousCommand = "$(echo INJECTED)";
+
+        // Act
+        var result = await executor.ExecuteCommandAsync(maliciousCommand);
+
+        // Assert
+        // If vulnerable, the output will contain "INJECTED"
+        result.Output.Should().Contain("INJECTED");
+    }
+
+    [Fact]
+    public async Task ExecuteCommandAsync_WithBacktickBreakout_ShouldConfirmVulnerability()
+    {
+        // Arrange
+        var executor = new ShellCommandExecutor(_mockLogger.Object);
+        string maliciousCommand = "`echo INJECTED`";
+
+        // Act
+        var result = await executor.ExecuteCommandAsync(maliciousCommand);
+
+        // Assert
+        result.Output.Should().Contain("INJECTED");
+    }
+
+    [Fact]
+    public async Task ExecuteDirectAsync_WithShellMetacharacters_ShouldNotEvaluateThem()
+    {
+        // Arrange
+        var executor = new ShellCommandExecutor(_mockLogger.Object);
+        // We try to pass $(echo INJECTED) as an argument to echo.
+        // If evaluated by a shell, it would output "INJECTED".
+        // If not evaluated (direct execution), it should output the literal string.
+        string maliciousArg = "$(echo INJECTED)";
+
+        // Act
+        var result = await executor.ExecuteDirectAsync("echo", [maliciousArg]);
+
+        // Assert
+        result.Output.Trim().Should().Be(maliciousArg);
+        result.Output.Should().NotContain("INJECTED");
+    }
+}


### PR DESCRIPTION
This PR addresses a critical command injection vulnerability in the `SerialPortDiscoveryService` and other areas of the codebase. The vulnerability was caused by passing unsanitized strings to `/bin/bash -c`.

### 🎯 What
The fix involves introducing a secure execution model that avoids shell interpretation. We now use `ProcessStartInfo.ArgumentList` to pass arguments directly to the operating system, ensuring they are treated as literal values rather than shell commands.

### ⚠️ Risk
Previously, an attacker could potentially execute arbitrary commands on the host system if they could control inputs that reached these services (e.g., a specially crafted serial port path). This could lead to full system compromise.

### 🛡️ Solution
1.  **Direct Execution:** Added `ExecuteDirectAsync` to run utilities like `stty`, `lsof`, `pgrep`, and `ps` without a shell.
2.  **Hardened Shell Execution:** Even when using a shell (via `ExecuteCommandAsync`), we now pass the command string to bash via `ArgumentList`, which prevents "breakout" attacks during the transition from C# to the shell.
3.  **Refactoring:** Removed vulnerable private methods and updated all call sites to use the new secure patterns.
4.  **Verification:** Added unit tests in `ShellCommandExecutorVulnerabilityTests` to prove that shell metacharacters are no longer evaluated by the direct execution path.

---
*PR created automatically by Jules for task [17379102554157555678](https://jules.google.com/task/17379102554157555678) started by @efargas*