### PR TITLE
🧪 Add tests for DataStoreLoggerProvider.UpdateConfiguration

### DIFF
--- a/tests/S7Tools.Infrastructure.Logging.Tests/Providers/Microsoft/DataStoreLoggerProviderTests.cs
+++ b/tests/S7Tools.Infrastructure.Logging.Tests/Providers/Microsoft/DataStoreLoggerProviderTests.cs
@@ -1,0 +1,100 @@
+using Moq;
+using S7Tools.Core.Services.Interfaces;
+using S7Tools.Infrastructure.Logging.Core.Configuration;
+using S7Tools.Infrastructure.Logging.Providers.Microsoft;
+
+namespace S7Tools.Infrastructure.Logging.Tests.Providers.Microsoft;
+
+public sealed class DataStoreLoggerProviderTests
+{
+    private readonly Mock<ILogDataStore> _mockDataStore;
+    private readonly Mock<ITimeProvider> _mockTimeProvider;
+    private readonly DataStoreLoggerProvider _provider;
+
+    public DataStoreLoggerProviderTests()
+    {
+        _mockDataStore = new Mock<ILogDataStore>();
+        _mockTimeProvider = new Mock<ITimeProvider>();
+        _provider = new DataStoreLoggerProvider(_mockDataStore.Object, _mockTimeProvider.Object);
+    }
+
+    [Fact]
+    public void UpdateConfiguration_NullConfiguration_ThrowsArgumentNullException()
+    {
+        // Act
+        Action act = () => _provider.UpdateConfiguration(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().WithParameterName("configuration");
+    }
+
+    [Fact]
+    public void UpdateConfiguration_ValidConfiguration_UpdatesInternalConfiguration()
+    {
+        // Arrange
+        var newConfig = new DataStoreLoggerConfiguration
+        {
+            LogLevel = LogLevel.Critical,
+            EventId = 123,
+            IncludeScopes = false,
+            CaptureProperties = false,
+            CategoryFilter = "Test.*",
+            FormatMessages = false,
+            MaxMessageLength = 500,
+            CaptureStackTrace = false
+        };
+
+        // Act
+        _provider.UpdateConfiguration(newConfig);
+
+        // Assert
+        _provider.Configuration.LogLevel.Should().Be(newConfig.LogLevel);
+        _provider.Configuration.EventId.Should().Be(newConfig.EventId);
+        _provider.Configuration.IncludeScopes.Should().Be(newConfig.IncludeScopes);
+        _provider.Configuration.CaptureProperties.Should().Be(newConfig.CaptureProperties);
+        _provider.Configuration.CategoryFilter.Should().Be(newConfig.CategoryFilter);
+        _provider.Configuration.FormatMessages.Should().Be(newConfig.FormatMessages);
+        _provider.Configuration.MaxMessageLength.Should().Be(newConfig.MaxMessageLength);
+        _provider.Configuration.CaptureStackTrace.Should().Be(newConfig.CaptureStackTrace);
+    }
+
+    [Fact]
+    public void UpdateConfiguration_WhenDisposed_DoesNotUpdate()
+    {
+        // Arrange
+        var initialLogLevel = _provider.Configuration.LogLevel;
+        _provider.Dispose();
+
+        var newConfig = new DataStoreLoggerConfiguration
+        {
+            LogLevel = LogLevel.Critical
+        };
+
+        // Act
+        _provider.UpdateConfiguration(newConfig);
+
+        // Assert
+        _provider.Configuration.LogLevel.Should().Be(initialLogLevel);
+    }
+
+    [Fact]
+    public void UpdateConfiguration_ReflectsInExistingLoggers()
+    {
+        // Arrange
+        var logger = (DataStoreLogger)_provider.CreateLogger("TestCategory");
+
+        var newConfig = new DataStoreLoggerConfiguration
+        {
+            LogLevel = LogLevel.Error
+        };
+
+        // Act
+        _provider.UpdateConfiguration(newConfig);
+
+        // Assert
+        // Since DataStoreLogger uses the same configuration object reference,
+        // it should reflect the changes.
+        logger.IsEnabled(LogLevel.Information).Should().BeFalse();
+        logger.IsEnabled(LogLevel.Error).Should().BeTrue();
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added unit tests for the `UpdateConfiguration` method in `DataStoreLoggerProvider`.
📊 **Coverage:** Covered the following scenarios:
- `ArgumentNullException` when passing a null configuration.
- Successful update of all configuration properties (LogLevel, EventId, etc.).
- Guard against updates when the provider is disposed.
- Verification that configuration updates propagate to existing loggers.
✨ **Result:** Increased test coverage for the logging infrastructure, ensuring configuration changes are correctly and safely applied.

---
*PR created automatically by Jules for task [17305124838631653811](https://jules.google.com/task/17305124838631653811) started by @efargas*