### PR TITLE
Fix Memory Viewer Bugs

### DIFF
--- a/src/S7Tools/Extensions/ServiceCollectionExtensions.cs
+++ b/src/S7Tools/Extensions/ServiceCollectionExtensions.cs
@@ -421,7 +421,7 @@ public static class ServiceCollectionExtensions
         services.TryAddTransient<ConfirmationDialogViewModel>();
 
         // Add Memory Dump Viewer ViewModel
-        services.TryAddSingleton<StreamedMemoryDumpViewModel>();
+        services.TryAddTransient<StreamedMemoryDumpViewModel>();
         services.TryAddSingleton<FileMemoryDumpViewModel>();
         services.TryAddTransient<FileMemoryDumpDocumentViewModel>();
         services.TryAddSingleton<MemoryDumpViewerViewModel>();

--- a/src/S7Tools/Factories/MainDockFactory.cs
+++ b/src/S7Tools/Factories/MainDockFactory.cs
@@ -83,6 +83,10 @@ public class MainDockFactory : Factory
             if (_mainDocumentDock!.VisibleDockables?.Contains(existingDoc) == true)
             {
                 _mainDocumentDock.ActiveDockable = existingDoc;
+                if (vm is IDisposable disposableVm && !ReferenceEquals(existingDoc.Context, vm))
+                {
+                    disposableVm.Dispose();
+                }
                 return;
             }
             else

--- a/src/S7Tools/Services/ApplicationSettingsService.cs
+++ b/src/S7Tools/Services/ApplicationSettingsService.cs
@@ -59,6 +59,7 @@ namespace S7Tools.Services
                 "profiles.socatPath" => settings.Profiles.SocatPath,
                 "profiles.powerSupplyPath" => settings.Profiles.PowerSupplyPath,
                 "profiles.memoryRegionPath" => settings.Profiles.MemoryRegionPath,
+                "profiles.memoryMappingPath" => settings.Profiles.MemoryRegionPath,
                 "powerSupply.powerStateChangeDelayMs" => settings.PowerSupply.PowerStateChangeDelayMs,
                 "memoryDump.defaultFolder" => settings.MemoryDump.DefaultFolder,
                 _ => null
@@ -103,7 +104,11 @@ namespace S7Tools.Services
                     case "profiles.serialPath": oldValue = settings.Profiles.SerialPath; settings.Profiles.SerialPath = value.ToString() ?? ""; break;
                     case "profiles.socatPath": oldValue = settings.Profiles.SocatPath; settings.Profiles.SocatPath = value.ToString() ?? ""; break;
                     case "profiles.powerSupplyPath": oldValue = settings.Profiles.PowerSupplyPath; settings.Profiles.PowerSupplyPath = value.ToString() ?? ""; break;
-                    case "profiles.memoryRegionPath": oldValue = settings.Profiles.MemoryRegionPath; settings.Profiles.MemoryRegionPath = value.ToString() ?? ""; break;
+                    case "profiles.memoryRegionPath":
+                    case "profiles.memoryMappingPath":
+                        oldValue = settings.Profiles.MemoryRegionPath;
+                        settings.Profiles.MemoryRegionPath = value.ToString() ?? "";
+                        break;
                     case "powerSupply.powerStateChangeDelayMs": oldValue = settings.PowerSupply.PowerStateChangeDelayMs; settings.PowerSupply.PowerStateChangeDelayMs = Convert.ToInt32(value); break;
                     case "memoryDump.defaultFolder": oldValue = settings.MemoryDump.DefaultFolder; settings.MemoryDump.DefaultFolder = value.ToString() ?? ""; break;
                 }
@@ -131,6 +136,7 @@ namespace S7Tools.Services
                 "profiles.socatPath" => def.Profiles.SocatPath,
                 "profiles.powerSupplyPath" => def.Profiles.PowerSupplyPath,
                 "profiles.memoryRegionPath" => def.Profiles.MemoryRegionPath,
+                "profiles.memoryMappingPath" => def.Profiles.MemoryRegionPath,
                 "powerSupply.powerStateChangeDelayMs" => def.PowerSupply.PowerStateChangeDelayMs,
                 "memoryDump.defaultFolder" => def.MemoryDump.DefaultFolder,
                 _ => null

--- a/src/S7Tools/ViewModels/Layout/NavigationViewModel.cs
+++ b/src/S7Tools/ViewModels/Layout/NavigationViewModel.cs
@@ -119,7 +119,7 @@ public class NavigationViewModel : ReactiveObject
         if (content is IDockableViewModel dockable && OpenDocumentAction != null)
         {
             // If the content is the generic memory dump shell, open its currently selected doc instead
-            if (dockable is MemoryDumpViewerViewModel memDumpVm && memDumpVm.SelectedCategoryViewModel is IDockableViewModel subDockable)
+            if (dockable is MemoryDumpViewerViewModel memDumpVm && memDumpVm.GetDockableForOpen() is IDockableViewModel subDockable)
             {
                 OpenDocumentAction(subDockable);
             }
@@ -171,7 +171,7 @@ public class NavigationViewModel : ReactiveObject
         {
             if (e.PropertyName == "SidebarItemTapped")
             {
-                if (_currentSidebarDockable is MemoryDumpViewerViewModel memDumpVm && memDumpVm.SelectedCategoryViewModel is IDockableViewModel subDockable)
+                if (_currentSidebarDockable is MemoryDumpViewerViewModel memDumpVm && memDumpVm.GetDockableForOpen() is IDockableViewModel subDockable)
                 {
                     OpenDocumentAction(subDockable);
                 }

--- a/src/S7Tools/ViewModels/Layout/NavigationViewModel.cs
+++ b/src/S7Tools/ViewModels/Layout/NavigationViewModel.cs
@@ -154,7 +154,14 @@ public class NavigationViewModel : ReactiveObject
     {
         if (_currentSidebarDockable != null && OpenDocumentAction != null)
         {
-            OpenDocumentAction(_currentSidebarDockable);
+            if (_currentSidebarDockable is MemoryDumpViewerViewModel memDumpVm && memDumpVm.GetDockableForOpen() is IDockableViewModel subDockable)
+            {
+                OpenDocumentAction(subDockable);
+            }
+            else
+            {
+                OpenDocumentAction(_currentSidebarDockable);
+            }
         }
     }
 

--- a/src/S7Tools/ViewModels/Pages/FileMemoryDumpViewModel.cs
+++ b/src/S7Tools/ViewModels/Pages/FileMemoryDumpViewModel.cs
@@ -53,6 +53,13 @@ public partial class FileMemoryDumpViewModel : ViewModelBase
         set => this.RaiseAndSetIfChanged(ref _rootFolderPath, value);
     }
 
+    private bool _hasItems;
+    public bool HasItems
+    {
+        get => _hasItems;
+        private set => this.RaiseAndSetIfChanged(ref _hasItems, value);
+    }
+
     public ObservableCollection<FileTreeItemViewModel> FileTreeItems { get; } = new();
 
     /// <summary>
@@ -90,6 +97,7 @@ public partial class FileMemoryDumpViewModel : ViewModelBase
     private void LoadTree()
     {
         FileTreeItems.Clear();
+        HasItems = false;
         if (string.IsNullOrEmpty(RootFolderPath)) return;
 
         try
@@ -97,6 +105,7 @@ public partial class FileMemoryDumpViewModel : ViewModelBase
             var root = new FileTreeItemViewModel(RootFolderPath, true);
             root.IsExpanded = true;
             FileTreeItems.Add(root);
+            HasItems = true;
         }
         catch (Exception ex)
         {
@@ -107,7 +116,7 @@ public partial class FileMemoryDumpViewModel : ViewModelBase
     [RelayCommand]
     private void OpenFile(FileTreeItemViewModel? item)
     {
-        if (item == null || item.IsDirectory || OpenDocumentAction == null) return;
+        if (item == null || item.IsDirectory || item.IsDummyNode || string.IsNullOrEmpty(item.FullPath) || OpenDocumentAction == null) return;
 
         try
         {

--- a/src/S7Tools/ViewModels/Pages/FileMemoryDumpViewModel.cs
+++ b/src/S7Tools/ViewModels/Pages/FileMemoryDumpViewModel.cs
@@ -41,6 +41,8 @@ public partial class FileMemoryDumpViewModel : ViewModelBase
             RootFolderPath = defaultFolder;
             LoadTree();
         }
+
+        FileTreeItems.CollectionChanged += (_, _) => this.RaisePropertyChanged(nameof(HasItems));
     }
 
     public string Title => "File PLC Memory Viewer";
@@ -53,12 +55,7 @@ public partial class FileMemoryDumpViewModel : ViewModelBase
         set => this.RaiseAndSetIfChanged(ref _rootFolderPath, value);
     }
 
-    private bool _hasItems;
-    public bool HasItems
-    {
-        get => _hasItems;
-        private set => this.RaiseAndSetIfChanged(ref _hasItems, value);
-    }
+    public bool HasItems => FileTreeItems.Count > 0;
 
     public ObservableCollection<FileTreeItemViewModel> FileTreeItems { get; } = new();
 
@@ -97,7 +94,7 @@ public partial class FileMemoryDumpViewModel : ViewModelBase
     private void LoadTree()
     {
         FileTreeItems.Clear();
-        HasItems = false;
+
         if (string.IsNullOrEmpty(RootFolderPath)) return;
 
         try
@@ -105,7 +102,7 @@ public partial class FileMemoryDumpViewModel : ViewModelBase
             var root = new FileTreeItemViewModel(RootFolderPath, true);
             root.IsExpanded = true;
             FileTreeItems.Add(root);
-            HasItems = true;
+
         }
         catch (Exception ex)
         {

--- a/src/S7Tools/ViewModels/Pages/FileTreeItemViewModel.cs
+++ b/src/S7Tools/ViewModels/Pages/FileTreeItemViewModel.cs
@@ -51,6 +51,8 @@ public partial class FileTreeItemViewModel : ViewModelBase
 
     public ObservableCollection<FileTreeItemViewModel> Children { get; } = new();
 
+    public bool IsDummyNode { get; private set; }
+
     public FileTreeItemViewModel(string path, bool isDirectory)
     {
         FullPath = path;
@@ -66,14 +68,20 @@ public partial class FileTreeItemViewModel : ViewModelBase
         if (IsDirectory)
         {
             // Add a dummy node so the expander arrow shows up
-            Children.Add(new FileTreeItemViewModel("Loading..."));
+            Children.Add(CreateDummyNode("Loading..."));
         }
     }
 
-    private FileTreeItemViewModel(string dummyName)
+    private FileTreeItemViewModel(bool isDummy, string dummyName)
     {
         Name = dummyName;
         IsDirectory = false;
+        IsDummyNode = isDummy;
+    }
+
+    public static FileTreeItemViewModel CreateDummyNode(string dummyName)
+    {
+        return new FileTreeItemViewModel(true, dummyName);
     }
 
     private void LoadChildren()
@@ -102,11 +110,11 @@ public partial class FileTreeItemViewModel : ViewModelBase
         }
         catch (UnauthorizedAccessException)
         {
-            Children.Add(new FileTreeItemViewModel("Access Denied", false));
+            Children.Add(CreateDummyNode("Access Denied"));
         }
         catch (Exception ex)
         {
-            Children.Add(new FileTreeItemViewModel($"Error: {ex.Message}", false));
+            Children.Add(CreateDummyNode($"Error: {ex.Message}"));
         }
     }
 }

--- a/src/S7Tools/ViewModels/Pages/FileTreeItemViewModel.cs
+++ b/src/S7Tools/ViewModels/Pages/FileTreeItemViewModel.cs
@@ -72,16 +72,16 @@ public partial class FileTreeItemViewModel : ViewModelBase
         }
     }
 
-    private FileTreeItemViewModel(bool isDummy, string dummyName)
+    private FileTreeItemViewModel(string dummyName)
     {
         Name = dummyName;
         IsDirectory = false;
-        IsDummyNode = isDummy;
+        IsDummyNode = true;
     }
 
     public static FileTreeItemViewModel CreateDummyNode(string dummyName)
     {
-        return new FileTreeItemViewModel(true, dummyName);
+        return new FileTreeItemViewModel(dummyName);
     }
 
     private void LoadChildren()

--- a/src/S7Tools/ViewModels/Pages/MemoryDumpViewerViewModel.cs
+++ b/src/S7Tools/ViewModels/Pages/MemoryDumpViewerViewModel.cs
@@ -21,12 +21,10 @@ public sealed class MemoryDumpViewerViewModel : ViewModelBase, IDockableViewMode
     public bool CanFloat => true;
 
     private readonly IServiceProvider _serviceProvider;
-    private readonly StreamedMemoryDumpViewModel _streamedViewModel;
 
     public MemoryDumpViewerViewModel(IServiceProvider serviceProvider)
     {
         _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
-        _streamedViewModel = _serviceProvider.GetRequiredService<StreamedMemoryDumpViewModel>();
         FileExplorer = _serviceProvider.GetRequiredService<FileMemoryDumpViewModel>();
 
         Categories = new ObservableCollection<string>(new[]
@@ -36,7 +34,7 @@ public sealed class MemoryDumpViewerViewModel : ViewModelBase, IDockableViewMode
 
         // Default selection
         SelectedCategory = Categories[0];
-        SelectedCategoryViewModel = GetCategoryViewModel(SelectedCategory);
+        // We don't cache instances here anymore. The dockable will be resolved on demand.
 
         SelectCategoryCommand = ReactiveCommand.Create<string>(category =>
         {
@@ -58,15 +56,13 @@ public sealed class MemoryDumpViewerViewModel : ViewModelBase, IDockableViewMode
         set
         {
             this.RaiseAndSetIfChanged(ref _selectedCategory, value);
-            SelectedCategoryViewModel = GetCategoryViewModel(value);
+            // No longer sets SelectedCategoryViewModel directly. UI/Navigation should call GetDockableForOpen()
         }
     }
 
-    private ViewModelBase? _selectedCategoryViewModel;
     public ViewModelBase? SelectedCategoryViewModel
     {
-        get => _selectedCategoryViewModel!;
-        set => this.RaiseAndSetIfChanged(ref _selectedCategoryViewModel, value);
+        get => null; // Kept for compatibility if XAML tries to bind it, but shouldn't be used
     }
 
     /// <summary>
@@ -89,17 +85,16 @@ public sealed class MemoryDumpViewerViewModel : ViewModelBase, IDockableViewMode
 
     public ReactiveCommand<string, Unit> SelectCategoryCommand { get; }
 
-    private ViewModelBase GetCategoryViewModel(string category)
+    public IDockableViewModel? GetDockableForOpen()
     {
-        return category switch
+        return SelectedCategory switch
         {
-            "Streamed PLC Memory Viewer" => _streamedViewModel,
-            _ => _streamedViewModel
+            "Streamed PLC Memory Viewer" => _serviceProvider.GetRequiredService<StreamedMemoryDumpViewModel>(),
+            _ => _serviceProvider.GetRequiredService<StreamedMemoryDumpViewModel>()
         };
     }
 
     public void Dispose()
     {
-        _streamedViewModel?.Dispose();
     }
 }

--- a/src/S7Tools/ViewModels/Pages/StreamedMemoryDumpViewModel.cs
+++ b/src/S7Tools/ViewModels/Pages/StreamedMemoryDumpViewModel.cs
@@ -117,11 +117,13 @@ public partial class StreamedMemoryDumpViewModel : ViewModelBase, S7Tools.Core.I
         MemoryBlocks = orchestrator.MemoryBlocks;
 
         // Subscribe to collection changes for statistics
-        MemoryBlocks.CollectionChanged += (s, e) =>
-        {
-            BlockCount = MemoryBlocks.Count;
-            TotalBytes = _orchestrator.TotalBytesReceived;
-        };
+        MemoryBlocks.CollectionChanged += OnMemoryBlocksCollectionChanged;
+    }
+
+    private void OnMemoryBlocksCollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+    {
+        BlockCount = MemoryBlocks.Count;
+        TotalBytes = _orchestrator.TotalBytesReceived;
     }
 
     /// <summary>
@@ -236,13 +238,39 @@ public partial class StreamedMemoryDumpViewModel : ViewModelBase, S7Tools.Core.I
     {
         if (disposing)
         {
+            MemoryBlocks.CollectionChanged -= OnMemoryBlocksCollectionChanged;
             if (IsConnected)
             {
-                Task.Run(async () => await DisconnectInternalAsync()).Wait();
+                _logger.LogInformation("Disposing active connection to memory dump session");
+
+                // Cancel synchronously to stop reading immediately
+                _cts?.Cancel();
+
+                // Fire and forget orchestrator shutdown so we don't block the UI thread
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        await _orchestrator.StopAsync();
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Error while stopping orchestrator during disposal");
+                    }
+                    finally
+                    {
+                        _cts?.Dispose();
+                        _cts = null;
+                    }
+                });
+
+                IsConnected = false;
+                ConnectionStatus = "Disconnected";
             }
             else
             {
                 _cts?.Dispose();
+                _cts = null;
             }
         }
     }

--- a/src/S7Tools/ViewModels/Pages/StreamedMemoryDumpViewModel.cs
+++ b/src/S7Tools/ViewModels/Pages/StreamedMemoryDumpViewModel.cs
@@ -236,9 +236,14 @@ public partial class StreamedMemoryDumpViewModel : ViewModelBase, S7Tools.Core.I
     {
         if (disposing)
         {
-            _cts?.Cancel();
-            _cts?.Dispose();
-            _cts = null;
+            if (IsConnected)
+            {
+                Task.Run(async () => await DisconnectInternalAsync()).Wait();
+            }
+            else
+            {
+                _cts?.Dispose();
+            }
         }
     }
 }

--- a/src/S7Tools/ViewModels/Settings/PathSettingsViewModel.cs
+++ b/src/S7Tools/ViewModels/Settings/PathSettingsViewModel.cs
@@ -58,7 +58,7 @@ public class PathSettingsViewModel : ViewModelBase
             if (args.Key == "profiles.serialPath" ||
                 args.Key == "profiles.socatPath" ||
                 args.Key == "profiles.powerSupplyPath" ||
-                args.Key == "profiles.memoryMappingPath")
+                args.Key == "profiles.memoryRegionPath")
             {
                 RefreshFromSettings();
             }
@@ -133,7 +133,7 @@ public class PathSettingsViewModel : ViewModelBase
         PowerSupplyProfilesPath = GetDirectoryFromPath(powerSupplyPath, _pathService.PowerSupplyProfilesPath);
 
         // Memory Region
-        string memoryRegionPath = _settingsService.GetSetting<string>("profiles.memoryMappingPath", _pathService.MemoryRegionProfilesPath);
+        string memoryRegionPath = _settingsService.GetSetting<string>("profiles.memoryRegionPath", _pathService.MemoryRegionProfilesPath);
         MemoryRegionProfilesPath = GetDirectoryFromPath(memoryRegionPath, _pathService.MemoryRegionProfilesPath);
     }
 
@@ -246,7 +246,7 @@ public class PathSettingsViewModel : ViewModelBase
     private Task ResetPowerSupplyProfilesPathAsync() => HandleResetPathAsync(_pathService.PowerSupplyProfilesPath, p => PowerSupplyProfilesPath = p, "profiles.powerSupplyPath", "PowerSupplyProfiles.json");
 
     // Memory Region
-    private Task BrowseMemoryRegionProfilesPathAsync() => HandleBrowsePathAsync(MemoryRegionProfilesPath, p => MemoryRegionProfilesPath = p, "profiles.memoryMappingPath", "MemoryMappingProfiles.json");
+    private Task BrowseMemoryRegionProfilesPathAsync() => HandleBrowsePathAsync(MemoryRegionProfilesPath, p => MemoryRegionProfilesPath = p, "profiles.memoryRegionPath", "MemoryMappingProfiles.json");
     private Task OpenMemoryRegionProfilesPathAsync() => HandleOpenPathAsync(MemoryRegionProfilesPath);
-    private Task ResetMemoryRegionProfilesPathAsync() => HandleResetPathAsync(_pathService.MemoryRegionProfilesPath, p => MemoryRegionProfilesPath = p, "profiles.memoryMappingPath", "MemoryMappingProfiles.json");
+    private Task ResetMemoryRegionProfilesPathAsync() => HandleResetPathAsync(_pathService.MemoryRegionProfilesPath, p => MemoryRegionProfilesPath = p, "profiles.memoryRegionPath", "MemoryMappingProfiles.json");
 }

--- a/src/S7Tools/Views/Pages/MemoryDumpSidebarView.axaml
+++ b/src/S7Tools/Views/Pages/MemoryDumpSidebarView.axaml
@@ -51,7 +51,7 @@
                     
                     <Grid DataContext="{Binding FileExplorer}">
                         <TextBlock Text="No folder selected" 
-                                 IsVisible="{Binding !FileTreeItems.Count}"
+                                 IsVisible="{Binding !HasItems}"
                                  Foreground="{DynamicResource TextForegroundMutedBrush}"
                                  Margin="16,8"
                                  FontStyle="Italic" />
@@ -59,7 +59,7 @@
                         <TreeView ItemsSource="{Binding FileTreeItems}" 
                                   Background="Transparent" 
                                   BorderThickness="0"
-                                  IsVisible="{Binding FileTreeItems.Count}"
+                                  IsVisible="{Binding HasItems}"
                                   Padding="4,0,0,0"
                                   DoubleTapped="OnTreeViewDoubleTapped">
                             <TreeView.ItemTemplate>

--- a/src/S7Tools/Views/Pages/MemoryDumpSidebarView.axaml.cs
+++ b/src/S7Tools/Views/Pages/MemoryDumpSidebarView.axaml.cs
@@ -26,7 +26,7 @@ public partial class MemoryDumpSidebarView : UserControl
     {
         if (DataContext is S7Tools.ViewModels.Pages.MemoryDumpViewerViewModel mainVm)
         {
-            if (mainVm.SelectedCategoryViewModel is S7Tools.Core.Interfaces.ViewModels.IDockableViewModel dockable)
+            if (mainVm.GetDockableForOpen() is S7Tools.Core.Interfaces.ViewModels.IDockableViewModel dockable)
             {
                 mainVm.OpenDocumentAction?.Invoke(dockable);
             }


### PR DESCRIPTION
This PR fixes a set of reported bugs in the memory viewer functionality:

1. **Disposed singleton dockable**: `StreamedMemoryDumpViewModel` was incorrectly registered as a `Singleton`. When the user closes its tab, the docking system naturally disposes the ViewModel context. Reopening the tab reused the same disposed `Singleton` instance. Fixed by changing its registration to `Transient`.
2. **Duplicate doc vm leak**: File exploration always created a new `FileMemoryDumpDocumentViewModel` without checking if the document for that path was already opened. Since `MainDockFactory` checks the `DockId` and skips redundant opening, the new ViewModel was never disposed, creating a resource leak. Fixed by updating `MainDockFactory.OpenDocument` to manually dispose any instance passed in when the given `DockId` is already an active/existing document.
3. **Broken isvisible count binding**: `IsVisible` states inside `MemoryDumpSidebarView.axaml` were bound directly to `FileTreeItems.Count` using negation and direct reference (`!FileTreeItems.Count` and `FileTreeItems.Count`), which expects an explicit bool converter in Avalonia. Fixed by adding a reactive `HasItems` boolean property on `FileMemoryDumpViewModel` to drive these `IsVisible` UI bindings properly.
4. **Placeholder nodes open files**: Dummy file tree nodes (like "Loading..." or "Access Denied") had an empty `FullPath` or a placeholder string path, but could still be opened because they weren't directories. Fixed by marking these with `IsDummyNode` property in `FileTreeItemViewModel` and refusing to open `IsDummyNode`s or empty `FullPath` entries in `FileMemoryDumpViewModel`. 
5. **PathSettingsViewModel key mismatch**: Typo in the settings keys in `PathSettingsViewModel.cs` - `profiles.memoryMappingPath` has been changed to `profiles.memoryRegionPath` so the UI mapping properly syncs with the data backend.

---
*PR created automatically by Jules for task [2096690482011337488](https://jules.google.com/task/2096690482011337488) started by @efargas*