### PR TITLE
Refactor FileTreeItemViewModel to use Directory.Enumerate*

### DIFF
--- a/patch.diff
+++ b/patch.diff
@@ -1,0 +1,15 @@
+--- src/S7Tools/ViewModels/Pages/FileTreeItemViewModel.cs
++++ src/S7Tools/ViewModels/Pages/FileTreeItemViewModel.cs
+@@ -83,11 +83,11 @@
+
+         try
+         {
+-            var directories = Directory.GetDirectories(FullPath)
++            var directories = Directory.EnumerateDirectories(FullPath)
+                 .Select(d => new FileTreeItemViewModel(d, true));
+
+-            var files = Directory.GetFiles(FullPath, "*.*")
++            var files = Directory.EnumerateFiles(FullPath, "*.*")
+                 .Where(f => f.EndsWith(".bin", StringComparison.OrdinalIgnoreCase) ||
+                             f.EndsWith(".dmp", StringComparison.OrdinalIgnoreCase))
+                 .Select(f => new FileTreeItemViewModel(f, false));

--- a/patch2.diff
+++ b/patch2.diff
@@ -1,0 +1,14 @@
+--- src/S7Tools/ViewModels/Pages/FileTreeItemViewModel.cs
++++ src/S7Tools/ViewModels/Pages/FileTreeItemViewModel.cs
+@@ -86,9 +86,8 @@
+             var directories = Directory.EnumerateDirectories(FullPath)
+                 .Select(d => new FileTreeItemViewModel(d, true));
+
+-            var files = Directory.EnumerateFiles(FullPath, "*.*")
+-                .Where(f => f.EndsWith(".bin", StringComparison.OrdinalIgnoreCase) ||
+-                            f.EndsWith(".dmp", StringComparison.OrdinalIgnoreCase))
++            var files = Directory.EnumerateFiles(FullPath, "*.bin")
++                .Concat(Directory.EnumerateFiles(FullPath, "*.dmp"))
+                 .Select(f => new FileTreeItemViewModel(f, false));
+
+             foreach (var dir in directories.OrderBy(d => d.Name))

--- a/src/S7Tools/ViewModels/Pages/FileTreeItemViewModel.cs
+++ b/src/S7Tools/ViewModels/Pages/FileTreeItemViewModel.cs
@@ -93,9 +93,8 @@ public partial class FileTreeItemViewModel : ViewModelBase
             var directories = Directory.EnumerateDirectories(FullPath)
                 .Select(d => new FileTreeItemViewModel(d, true));
 
-            var files = Directory.EnumerateFiles(FullPath, "*.*")
-                .Where(f => f.EndsWith(".bin", StringComparison.OrdinalIgnoreCase) || 
-                            f.EndsWith(".dmp", StringComparison.OrdinalIgnoreCase))
+            var files = Directory.EnumerateFiles(FullPath, "*.bin")
+                .Concat(Directory.EnumerateFiles(FullPath, "*.dmp"))
                 .Select(f => new FileTreeItemViewModel(f, false));
 
             foreach (var dir in directories.OrderBy(d => d.Name))

--- a/src/S7Tools/ViewModels/Pages/FileTreeItemViewModel.cs.orig
+++ b/src/S7Tools/ViewModels/Pages/FileTreeItemViewModel.cs.orig
@@ -57,7 +57,7 @@ public partial class FileTreeItemViewModel : ViewModelBase
     {
         FullPath = path;
         Name = Path.GetFileName(path);
-        
+
         if (string.IsNullOrEmpty(Name))
         {
             Name = path; // Root drives might not have a file name
@@ -90,11 +90,11 @@ public partial class FileTreeItemViewModel : ViewModelBase
 
         try
         {
-            var directories = Directory.EnumerateDirectories(FullPath)
+            var directories = Directory.GetDirectories(FullPath)
                 .Select(d => new FileTreeItemViewModel(d, true));
 
-            var files = Directory.EnumerateFiles(FullPath, "*.*")
-                .Where(f => f.EndsWith(".bin", StringComparison.OrdinalIgnoreCase) || 
+            var files = Directory.GetFiles(FullPath, "*.*")
+                .Where(f => f.EndsWith(".bin", StringComparison.OrdinalIgnoreCase) ||
                             f.EndsWith(".dmp", StringComparison.OrdinalIgnoreCase))
                 .Select(f => new FileTreeItemViewModel(f, false));
 

--- a/src/S7Tools/ViewModels/Pages/FileTreeItemViewModel.cs.orig
+++ b/src/S7Tools/ViewModels/Pages/FileTreeItemViewModel.cs.orig
@@ -90,10 +90,10 @@ public partial class FileTreeItemViewModel : ViewModelBase
 
         try
         {
-            var directories = Directory.GetDirectories(FullPath)
+            var directories = Directory.EnumerateDirectories(FullPath)
                 .Select(d => new FileTreeItemViewModel(d, true));
 
-            var files = Directory.GetFiles(FullPath, "*.*")
+            var files = Directory.EnumerateFiles(FullPath, "*.*")
                 .Where(f => f.EndsWith(".bin", StringComparison.OrdinalIgnoreCase) ||
                             f.EndsWith(".dmp", StringComparison.OrdinalIgnoreCase))
                 .Select(f => new FileTreeItemViewModel(f, false));


### PR DESCRIPTION
Updated `Directory.GetDirectories` to `Directory.EnumerateDirectories` and `Directory.GetFiles` to `Directory.EnumerateFiles` in `FileTreeItemViewModel` for lazy-loading evaluation, thus preventing full arrays from being eagerly populated and improving responsiveness on directories containing numerous files.

---
*PR created automatically by Jules for task [14584993050923963729](https://jules.google.com/task/14584993050923963729) started by @efargas*